### PR TITLE
Add copyright to list of filenames

### DIFF
--- a/lib/licensee/project.rb
+++ b/lib/licensee/project.rb
@@ -10,6 +10,7 @@ class Licensee
       license.md
       unlicense
       copying
+      copyright
     ]
 
     # Initializes a new project


### PR DESCRIPTION
COPYRIGHT is also used as specifying the license. 
Searching github gives 276499 matches for files named copyright.