### PR TITLE
Use also other filename than LICENSE in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Matcher: Licensee::GitMatcher
 
 ## What it looks at
 
-* `LICENSE`, `LICENSE.txt`, etc. files in the root of the project, comparing the body to known licenses
+* `LICENSE`, `LICENSE.txt`, `COPYING`, etc. files in the root of the project, comparing the body to known licenses
 * Crowdsourced license content and metadata from [`choosealicense.com`](http://choosealicense.com)
 
 ## What it doesn't look at


### PR DESCRIPTION
I had to inspect the source to see if only LICENSE files with different extensions are inspected, or other common files, such as COPYING are inspected as well. This makes it more clear.