### PR TITLE
Strip leading newlines from license body

### DIFF
--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -70,7 +70,7 @@ class Licensee
     private
 
     def parts
-      @parts ||= content.match(/^(---\n.*\n---)?(.*)/m).to_a
+      @parts ||= content.match(/^(---\n.*\n---\n+)?(.*)/m).to_a
     end
   end
 end

--- a/test/test_licensee_license.rb
+++ b/test/test_licensee_license.rb
@@ -46,4 +46,8 @@ class TestLicenseeLicense < Minitest::Test
     assert_equal Array, Licensee::License.all.class
     assert Licensee::License.all.size > 3
   end
+
+  should "strip leading newlines from the license" do
+    assert_equal "T", @license.body[0]
+  end
 end


### PR DESCRIPTION
They're an artifact of the YAML front matter divider.

The first line of the license should be the license title, not a new line.

This also more accurately parses YAML Front matter by requiring a newline after the divider.

