### PR TITLE
Better YAML front matter regex

### DIFF
--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -70,7 +70,7 @@ class Licensee
     private
 
     def parts
-      @parts ||= content.match(/^(---\n.*\n---\n+)?(.*)/m).to_a
+      @parts ||= content.match(/\A(---\n.*\n---\n+)?(.*)/m).to_a
     end
   end
 end


### PR DESCRIPTION
Use the `\A` anchor, not `^`.