### PR TITLE
Enable passing directory explicitly in `licensee` CLI tool

### DIFF
--- a/bin/licensee
+++ b/bin/licensee
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
-
 require_relative "../lib/licensee"
-project = Licensee::Project.new(Dir.pwd)
+
+path = ARGV[0] || Dir.pwd
+
+project = Licensee::Project.new(path)
 license = project.license_file
 
 if license


### PR DESCRIPTION
This is so you don't have to change directory to look up a license