### PR TITLE
Expose license_file path

### DIFF
--- a/bin/licensee
+++ b/bin/licensee
@@ -7,7 +7,7 @@ project = Licensee::Project.new(path)
 license = project.license_file
 
 if license
-  puts "License file: #{project.send(:license_blob)[:name]}"
+  puts "License file: #{license.path}"
   puts "License: #{license.match ? license.match.meta['title'] : 'no license'}"
   puts "Confidence: #{license.confidence}%"
   puts "Method: #{license.matcher.class}"

--- a/lib/licensee/license_file.rb
+++ b/lib/licensee/license_file.rb
@@ -1,9 +1,10 @@
 class Licensee
   class LicenseFile
-    attr_reader :blob
+    attr_reader :blob, :path
 
-    def initialize(blob)
+    def initialize(blob, options={})
       @blob = blob
+      @path = options[:path]
     end
 
     def similarity(other)

--- a/lib/licensee/project.rb
+++ b/lib/licensee/project.rb
@@ -37,7 +37,7 @@ class Licensee
 
     # Returns an instance of Licensee::LicenseFile if there's a license file detected
     def license_file
-      @license_file ||= LicenseFile.new(@repository.lookup(license_blob[:oid])) if license_blob
+      @license_file ||= LicenseFile.new(license_blob, :path => license_path) if license_blob
     end
 
     # Returns the matching Licensee::License instance if a license can be detected
@@ -57,12 +57,20 @@ class Licensee
 
     # Detects the license file, if any
     # Returns the blob hash as detected in the tree
-    def license_blob
+    def license_hash
       # Prefer an exact match to one of our known file names
-      license_blob = tree.find { |blob| LICENSE_FILENAMES.include? blob[:name].downcase }
+      license_hash = tree.find { |blob| LICENSE_FILENAMES.include? blob[:name].downcase }
 
       # Fall back to the first file in the project root that has the word license in it
-      license_blob || tree.find { |blob| blob[:name] =~ /licen(s|c)e/i }
+      license_hash || tree.find { |blob| blob[:name] =~ /licen(s|c)e/i }
+    end
+
+    def license_blob
+      @repository.lookup(license_hash[:oid]) if license_hash
+    end
+
+    def license_path
+      license_hash[:name] if license_hash
     end
   end
 end

--- a/test/test_licensee_bin.rb
+++ b/test/test_licensee_bin.rb
@@ -6,6 +6,7 @@ class TestLicenseeBin < Minitest::Test
     Dir.chdir root
     stdout,stderr,status = Open3.capture3("#{root}/bin/licensee")
     assert stdout.include?("License: MIT"), "expected #{stdout} to include `License: MIT`"
+    assert stdout.include?("License file: LICENSE.md"), "expected #{stdout} to include `License file: LICENSE.md`"
     assert_equal 0, status
   end
 end

--- a/test/test_licensee_copyright_matcher.rb
+++ b/test/test_licensee_copyright_matcher.rb
@@ -36,4 +36,11 @@ class TestLicenseeCopyrightMatcher < Minitest::Test
     file = Licensee::LicenseFile.new(blob)
     assert_equal nil, Licensee::CopyrightMatcher.match(file)
   end
+
+  should "handle UTF-8 encoded copyright notices" do
+    text = "Copyright (c) 2010-2014 Simon Hürlimann"
+    blob = FakeBlob.new(text)
+    file = Licensee::LicenseFile.new(blob)
+    assert_equal "no-license", Licensee::CopyrightMatcher.match(file).key
+  end
 end

--- a/test/test_licensee_license_file.rb
+++ b/test/test_licensee_license_file.rb
@@ -5,7 +5,7 @@ class TestLicenseeLicenseFile < Minitest::Test
   def setup
     @repo = Rugged::Repository.new(fixture_path("licenses.git"))
     blob = 'bcb552d06d9cf1cd4c048a6d3bf716849c2216cc'
-    @file = Licensee::LicenseFile.new(@repo.lookup(blob))
+    @file = Licensee::LicenseFile.new(@repo.lookup(blob), :path => "LICENSE")
     @gpl = Licensee::Licenses.find "GPL-3.0"
     @mit = Licensee::Licenses.find "MIT"
   end
@@ -16,6 +16,10 @@ class TestLicenseeLicenseFile < Minitest::Test
 
   should "match the license" do
     assert_equal "mit", @file.match.key
+  end
+
+  should "know the path" do
+    assert_equal "LICENSE", @file.path
   end
 
   should "diff the file" do

--- a/test/test_licensee_project.rb
+++ b/test/test_licensee_project.rb
@@ -36,9 +36,19 @@ class TestLicenseeProject < Minitest::Test
         assert_equal "mit", project.license.key
       end
 
+      should "return the license hash" do
+        project = make_project "licenses.git", as_git
+        assert_equal "LICENSE", project.send(:license_hash)[:name]
+      end
+
       should "return the license blob" do
         project = make_project "licenses.git", as_git
-        assert_equal "LICENSE", project.send(:license_blob)[:name]
+        assert_equal 1077, project.send(:license_blob).size
+      end
+
+      should "return the license path" do
+        project = make_project "licenses.git", as_git
+        assert_equal "LICENSE", project.send(:license_path)
       end
 
       should "detect an atypically cased license file" do


### PR DESCRIPTION
Add a `path` method to `license_file` to expose the name of the license file