### PR TITLE
Better file matching regex

### DIFF
--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -19,15 +19,11 @@ class Licensee
     # Raw content of license file, including YAML front matter
     def content
       @content ||= File.open(path).read
-    rescue
-      ""
     end
 
     # License metadata from YAML front matter
     def meta
       @meta ||= YAML.load(parts[1]) if parts[1]
-    rescue
-      nil
     end
 
     def name

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -1,4 +1,5 @@
 class Licensee
+  class InvalidLicense < ArgumentError; end
   class License
 
     def self.all
@@ -18,7 +19,11 @@ class Licensee
 
     # Raw content of license file, including YAML front matter
     def content
-      @content ||= File.open(path).read
+      @content ||= if File.exists?(path)
+        File.open(path).read
+      else
+        raise Licensee::InvalidLicense, "'#{key}' is not a valid license key"
+      end
     end
 
     # License metadata from YAML front matter

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -21,6 +21,8 @@ class Licensee
     def content
       @content ||= if File.exists?(path)
         File.open(path).read
+      elsif key == "other" # A pseudo-license with no content
+        nil
       else
         raise Licensee::InvalidLicense, "'#{key}' is not a valid license key"
       end
@@ -28,11 +30,12 @@ class Licensee
 
     # License metadata from YAML front matter
     def meta
-      @meta ||= YAML.load(parts[1]) if parts[1]
+      @meta ||= YAML.load(parts[1]) if parts && parts[1]
     end
 
+    # Returns the human-readable license name
     def name
-      meta["title"] if meta
+      meta.nil? ? key.capitalize : meta["title"]
     end
 
     def featured?
@@ -42,7 +45,7 @@ class Licensee
 
     # The license body (e.g., contents - frontmatter)
     def body
-      @body ||= parts[2] if parts[2]
+      @body ||= parts[2] if parts && parts[2]
     end
     alias_method :to_s, :body
     alias_method :text, :body
@@ -71,7 +74,7 @@ class Licensee
     private
 
     def parts
-      @parts ||= content.match(/\A(---\n.*\n---\n+)?(.*)/m).to_a
+      @parts ||= content.match(/\A(---\n.*\n---\n+)?(.*)/m).to_a if content
     end
   end
 end

--- a/lib/licensee/project.rb
+++ b/lib/licensee/project.rb
@@ -2,17 +2,6 @@ class Licensee
   class Project
     attr_reader :repository
 
-    # Array of file names to look for potential license files, in order
-    # Filenames should be lower case as candidates are downcased before comparison
-    LICENSE_FILENAMES = %w[
-      license
-      license.txt
-      license.md
-      unlicense
-      copying
-      copyright
-    ]
-
     # Initializes a new project
     #
     # path_or_repo path to git repo or Rugged::Repository instance
@@ -45,6 +34,27 @@ class Licensee
       @license ||= license_file.match if license_file
     end
 
+    # Regex to detect license files
+    #
+    # Examples it should match:
+    # - LICENSE.md
+    # - licence.txt
+    # - unlicense
+    # - copying
+    # - copyright
+    def self.license_file?(filename)
+      !!(filename =~ /\A(un)?licen[sc]e|copy(ing|right)(\.[^.]+)?\z/i)
+    end
+
+    # Regex to detect things that look like license files
+    #
+    # Examples it should match:
+    # - license-MIT.txt
+    # - MIT-LICENSE
+    def self.maybe_license_file?(filename)
+      !!(filename =~ /licen[sc]e/i)
+    end
+
     private
 
     def commit
@@ -58,11 +68,8 @@ class Licensee
     # Detects the license file, if any
     # Returns the blob hash as detected in the tree
     def license_hash
-      # Prefer an exact match to one of our known file names
-      license_hash = tree.find { |blob| LICENSE_FILENAMES.include? blob[:name].downcase }
-
-      # Fall back to the first file in the project root that has the word license in it
-      license_hash || tree.find { |blob| blob[:name] =~ /licen(s|c)e/i }
+      license_hash = tree.find { |blob| self.class.license_file?(blob[:name]) }
+      license_hash ||= tree.find { |blob| self.class.maybe_license_file?(blob[:name]) }
     end
 
     def license_blob

--- a/lib/licensee/project.rb
+++ b/lib/licensee/project.rb
@@ -42,7 +42,7 @@ class Licensee
     # Return 0.5 if the file is likely a license file
     # Returns 0 if the file is definately not a license file
     def self.match_license_file(filename)
-      return 1 if self.license_file?(filename)
+      return 1   if self.license_file?(filename)
       return 0.5 if self.maybe_license_file?(filename)
       return 0
     end

--- a/lib/licensee/project.rb
+++ b/lib/licensee/project.rb
@@ -34,6 +34,13 @@ class Licensee
       @license ||= license_file.match if license_file
     end
 
+    # Scores a given file as a potential license
+    #
+    # filename - (string) the name of the file to score
+    #
+    # Returns 1 if the file is definately a license file
+    # Return 0.5 if the file is likely a license file
+    # Returns 0 if the file is definately not a license file
     def self.match_license_file(filename)
       return 1 if self.license_file?(filename)
       return 0.5 if self.maybe_license_file?(filename)

--- a/lib/licensee/project.rb
+++ b/lib/licensee/project.rb
@@ -34,25 +34,10 @@ class Licensee
       @license ||= license_file.match if license_file
     end
 
-    # Regex to detect license files
-    #
-    # Examples it should match:
-    # - LICENSE.md
-    # - licence.txt
-    # - unlicense
-    # - copying
-    # - copyright
-    def self.license_file?(filename)
-      !!(filename =~ /\A(un)?licen[sc]e|copy(ing|right)(\.[^.]+)?\z/i)
-    end
-
-    # Regex to detect things that look like license files
-    #
-    # Examples it should match:
-    # - license-MIT.txt
-    # - MIT-LICENSE
-    def self.maybe_license_file?(filename)
-      !!(filename =~ /licen[sc]e/i)
+    def self.match_license_file(filename)
+      return 1 if self.license_file?(filename)
+      return 0.5 if self.maybe_license_file?(filename)
+      return 0
     end
 
     private
@@ -78,6 +63,27 @@ class Licensee
 
     def license_path
       license_hash[:name] if license_hash
+    end
+
+    # Regex to detect license files
+    #
+    # Examples it should match:
+    # - LICENSE.md
+    # - licence.txt
+    # - unlicense
+    # - copying
+    # - copyright
+    def self.license_file?(filename)
+      !!(filename =~ /\A(un)?licen[sc]e|copy(ing|right)(\.[^.]+)?\z/i)
+    end
+
+    # Regex to detect things that look like license files
+    #
+    # Examples it should match:
+    # - license-MIT.txt
+    # - MIT-LICENSE
+    def self.maybe_license_file?(filename)
+      !!(filename =~ /licen[sc]e/i)
     end
   end
 end

--- a/lib/licensee/version.rb
+++ b/lib/licensee/version.rb
@@ -1,3 +1,3 @@
 class Licensee
-  VERSION = "4.6.0"
+  VERSION = "4.7.0"
 end

--- a/licensee.gemspec
+++ b/licensee.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('rugged', '~> 0.23.0b1')
   gem.add_dependency('levenshtein-ffi', '~> 1.1')
-  gem.add_dependency('stanford-core-nlp')
 
   gem.add_development_dependency('pry', '~> 0.9')
   gem.add_development_dependency('shoulda', '~> 3.5')

--- a/licensee.gemspec
+++ b/licensee.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('rugged', '~> 0.23.0b1')
   gem.add_dependency('levenshtein-ffi', '~> 1.1')
-
   gem.add_development_dependency('pry', '~> 0.9')
   gem.add_development_dependency('shoulda', '~> 3.5')
   gem.add_development_dependency('rake', '~> 10.3')

--- a/licensee.gemspec
+++ b/licensee.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('rugged', '~> 0.23.0b1')
   gem.add_dependency('levenshtein-ffi', '~> 1.1')
+  gem.add_dependency('stanford-core-nlp')
+
   gem.add_development_dependency('pry', '~> 0.9')
   gem.add_development_dependency('shoulda', '~> 3.5')
   gem.add_development_dependency('rake', '~> 10.3')

--- a/test/test_licensee_license.rb
+++ b/test/test_licensee_license.rb
@@ -30,8 +30,8 @@ class TestLicenseeLicense < Minitest::Test
   should "know if the license is featured" do
     assert @license.featured?
     assert_equal TrueClass, @license.featured?.class
-    refute Licensee::License.new("cc0").featured?
-    assert_equal FalseClass, Licensee::License.new("cc0").featured?.class
+    refute Licensee::License.new("cc0-1.0").featured?
+    assert_equal FalseClass, Licensee::License.new("cc0-1.0").featured?.class
   end
 
   should "parse the license parts" do

--- a/test/test_licensee_license.rb
+++ b/test/test_licensee_license.rb
@@ -50,4 +50,8 @@ class TestLicenseeLicense < Minitest::Test
   should "strip leading newlines from the license" do
     assert_equal "T", @license.body[0]
   end
+
+  should "fail loudly for invalid licenses" do
+    assert_raises(Licensee::InvalidLicense) { Licensee::License.new("foo").name }
+  end
 end

--- a/test/test_licensee_license.rb
+++ b/test/test_licensee_license.rb
@@ -54,4 +54,11 @@ class TestLicenseeLicense < Minitest::Test
   should "fail loudly for invalid licenses" do
     assert_raises(Licensee::InvalidLicense) { Licensee::License.new("foo").name }
   end
+
+  should "support 'other' licenses" do
+    license = Licensee::License.new("other")
+    assert_equal nil, license.content
+    assert_equal "Other", license.name
+    refute license.featured?
+  end
 end

--- a/test/test_licensee_project.rb
+++ b/test/test_licensee_project.rb
@@ -110,5 +110,11 @@ class TestLicenseeProject < Minitest::Test
         assert Licensee::Project.maybe_license_file?(license)
       end
     end
+
+    should "return the proper license files scores" do
+      assert_equal 1,   Licensee::Project.match_license_file("LICENSE.md")
+      assert_equal 0.5, Licensee::Project.match_license_file("MIT-LICENSE")
+      assert_equal 0,   Licensee::Project.match_license_file("README.txt")
+    end
   end
 end

--- a/test/test_licensee_project.rb
+++ b/test/test_licensee_project.rb
@@ -79,4 +79,36 @@ class TestLicenseeProject < Minitest::Test
     end
   end
 
+  context "license filename matching" do
+    # Standard license names
+    ["license",
+      "LICENSE",
+      "LICENCE",
+      "license.md",
+      "unlicense",
+      "unlicence",
+      "copying",
+      "copyRIGHT",
+      "license.txt"
+    ].each do |license|
+      should "match #{license}" do
+        assert Licensee::Project.license_file?(license)
+      end
+    end
+
+    should "not match MIT-LICENSE" do
+      refute Licensee::Project.license_file?("MIT-LICENSE")
+    end
+
+    # Abnormal license names
+    [
+      "LICENSE-MIT",
+      "MIT-LICENSE.txt",
+      "mit-license-foo.md"
+    ].each do |license|
+      should "match #{license}" do
+        assert Licensee::Project.maybe_license_file?(license)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Which exposes ~~`Licensee::Project.license_file?` and `Licensee::Project.maybe_license_file?` methods~~ `Licensee::Project.match_license_file` for use outside of Licensee.

//cc @mislav 