### PR TITLE
Check if safe_yaml exists before calling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.0
   - 2.1
   - 2.2
 script: "script/cibuild"

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -30,7 +30,13 @@ class Licensee
 
     # License metadata from YAML front matter
     def meta
-      @meta ||= YAML.safe_load(parts[1]) if parts && parts[1]
+      @meta ||= if parts && parts[1]
+        if YAML.respond_to? :safe_yaml
+          YAML.safe_load(parts[1])
+        else
+          YAML.load(parts[1])
+        end
+      end
     end
 
     # Returns the human-readable license name


### PR DESCRIPTION
Via https://github.com/benbalter/licensee/pull/37#issuecomment-123057842, the idea is that `safe_yaml` is a nice to have paranoia, but isn't strictly necessary. Rather than require a major bump/breaking change, lets use safe_yaml if we got it, and if not, fall back to vanilla `YAML.load`. 

This also adds a travis check for Ruby 2.0.

/cc @mislav, @ptoomey3, https://github.com/benbalter/licensee/pull/37