### PR TITLE
Fix a typo in lib/licensee.rb

### DIFF
--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -17,7 +17,7 @@ require_relative "licensee/matchers/levenshtein_matcher"
 
 class Licensee
 
-  # Over watch percent is a match considered a match
+  # Over which percent is a match considered a match
   CONFIDENCE_THRESHOLD = 90
 
   # Base domain from which to build license URLs


### PR DESCRIPTION
:eyes: :mag_right: 