### PR TITLE
Attach Travis badge to the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *A Ruby Gem to detect under what license a project is distributed.*
 
-[![Build Status](https://travis-ci.org/benbalter/licensee.svg)](https://travis-ci.org/benbalter/licensee) [![Gem Version](https://badge.fury.io/rb/licensee.svg)](http://badge.fury.io/rb/licensee)
+[![Build Status](https://travis-ci.org/benbalter/licensee.svg?branch=master)](https://travis-ci.org/benbalter/licensee) [![Gem Version](https://badge.fury.io/rb/licensee.svg)](http://badge.fury.io/rb/licensee)
 
 ## The problem
 


### PR DESCRIPTION
This pull request attaches the Travis badge to the `master` branch to prevent it from displaying a `failing` status for other branches or PRs.
It's a minor change but [the current badge](https://travis-ci.org/benbalter/licensee/builds/72611251) scared me :stuck_out_tongue: 