### PR TITLE
confirm license contains the license name or nickname if it should

### DIFF
--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -76,6 +76,14 @@ class Licensee
       meta.nil? ? key.capitalize : meta["title"]
     end
 
+    def nickname
+      meta["nickname"] if meta
+    end
+
+    def name_without_version
+      /(.+?)(( v?\d\.\d)|$)/.match(name)[1]
+    end
+
     def featured?
       !!(meta["featured"] if meta)
     end
@@ -116,6 +124,14 @@ class Licensee
 
     def ==(other)
       other != nil && key == other.key
+    end
+
+    def body_includes_name?
+      @body_includes_name ||= body_normalized.include?(name_without_version.downcase)
+    end
+
+    def body_includes_nickname?
+      @body_includes_nickname ||= !!(nickname && body_normalized.include?(nickname.downcase))
     end
 
     private

--- a/lib/licensee/matchers/git_matcher.rb
+++ b/lib/licensee/matchers/git_matcher.rb
@@ -2,7 +2,7 @@ class Licensee
   class GitMatcher < Matcher
 
     def match
-      match_info[0] unless match_info.nil?
+      match_info[0] if match_info && match_info[1] >= Licensee.confidence_threshold
     end
 
     def confidence
@@ -19,7 +19,7 @@ class Licensee
     def match_info
       @match_info ||= begin
         match = matches.max_by { |license, similarity| similarity }
-        match if match && match[1] > Licensee.confidence_threshold
+        match if match
       end
     end
   end

--- a/lib/licensee/matchers/levenshtein_matcher.rb
+++ b/lib/licensee/matchers/levenshtein_matcher.rb
@@ -8,8 +8,8 @@ class Licensee
         # If we know the license text contains the license name or nickname,
         # bail early unless the file we're checking contains it.
         # Guards against OSL & AFL confusion. See https://github.com/benbalter/licensee/issues/50
-        return false if license.body_includes_name? && !includes_license_name?(license)
-        return false if license.body_includes_nickname? && !includes_license_nickname?(license)
+        next if license.body_includes_name? && !includes_license_name?(license)
+        next if license.body_includes_nickname? && !includes_license_nickname?(license)
 
         similarity(license) >= Licensee.confidence_threshold
       end
@@ -68,7 +68,7 @@ class Licensee
     end
 
     def includes_license_nickname?(license)
-       license.nickname && file.content_normalized.include?(license.nickname.downcase)
+      license.nickname && file.content_normalized.include?(license.nickname.downcase)
     end
   end
 end

--- a/lib/licensee/matchers/levenshtein_matcher.rb
+++ b/lib/licensee/matchers/levenshtein_matcher.rb
@@ -4,6 +4,13 @@ class Licensee
     # Return the first potential license that is more similar than the confidence threshold
     def match
       @match ||= potential_licenses.find do |license|
+
+        # If we know the license text contains the license name or nickname,
+        # bail early unless the file we're checking contains it.
+        # Guards against OSL & AFL confusion. See https://github.com/benbalter/licensee/issues/50
+        return false if license.body_includes_name? && !includes_license_name?(license)
+        return false if license.body_includes_nickname? && !includes_license_nickname?(license)
+
         similarity(license) >= Licensee.confidence_threshold
       end
     end
@@ -12,7 +19,9 @@ class Licensee
     # Difference in lengths cannot exceed the file's length * the confidence threshold / 100
     def potential_licenses
       @potential_licenses ||= begin
-        Licensee.licenses(:hidden => true).select { |license| length_delta(license) <= max_delta }.sort_by { |l| length_delta(l) }
+        licenses = Licensee.licenses(:hidden => true)
+        licenses = licenses.select { |license| length_delta(license) <= max_delta }
+        licenses.sort_by { |l| length_delta(l) }
       end
     end
 
@@ -50,6 +59,14 @@ class Licensee
     # work faster. As long as they both undergo the same transformation, should match.
     def distance(license)
       Levenshtein.distance(license.body_normalized, file.content_normalized).to_f
+    end
+
+    def includes_license_name?(license)
+      file.content_normalized.include?(license.name_without_version.downcase)
+    end
+
+    def includes_license_nickname?(license)
+       license.nickname && file.content_normalized.include?(license.nickname.downcase)
     end
   end
 end

--- a/test/fixtures/mit-without-title/mit.txt
+++ b/test/fixtures/mit-without-title/mit.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Ben Balter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/test/functions.rb
+++ b/test/functions.rb
@@ -22,8 +22,8 @@ end
 FakeBlob = Licensee::FilesystemRepository::Blob
 
 def chaos_monkey(string)
-  Random.rand(5).times do
-    string[Random.rand(string.length)] = SecureRandom.base64(Random.rand(5))
+  Random.rand(3).times do
+    string[Random.rand(string.length)] = SecureRandom.base64(Random.rand(3))
   end
   string
 end

--- a/test/functions.rb
+++ b/test/functions.rb
@@ -39,7 +39,17 @@ def verify_license_file(license, chaos = false, wrap=false)
   license_file = Licensee::ProjectFile.new(blob, "LICENSE")
 
   actual = license_file.match
-  assert actual, "No match for #{expected}. Here's the test text:\n#{text}"
+  msg = "No match for #{expected}."
+
+  unless actual
+    Licensee.matchers.each do |matcher|
+      matcher = matcher.new(license_file)
+      msg << "#{matcher.class}: #{matcher.confidence}% #{matcher.match.inspect}\n"
+    end
+    msg << "Here's the test text:\n#{text}"
+  end
+
+  assert actual, msg
   assert_equal expected, actual.key, "expeceted #{expected} but got #{actual.key} for .match. Confidence: #{license_file.confidence}. Method: #{license_file.matcher.class}"
 end
 

--- a/test/test_licensee_git_matcher.rb
+++ b/test/test_licensee_git_matcher.rb
@@ -15,4 +15,5 @@ class TestLicenseeGitMatcher < Minitest::Test
   should "know the match confidence" do
     assert_equal 94, Licensee::GitMatcher.new(@mit).confidence
   end
+
 end

--- a/test/test_licensee_license.rb
+++ b/test/test_licensee_license.rb
@@ -30,6 +30,11 @@ class TestLicenseeLicense < Minitest::Test
     assert_equal "MIT License", @license.name
   end
 
+  should "know the license nickname" do
+    expected = "GNU Affero GPL v3.0"
+    assert_equal expected, Licensee::License.find("agpl-3.0").nickname
+  end
+
   should "know the license ID" do
     assert_equal "mit", @license.key
   end
@@ -96,6 +101,32 @@ class TestLicenseeLicense < Minitest::Test
     assert_equal nil, license.content
     assert_equal "Other", license.name
     refute license.featured?
+  end
+
+  describe "name without version" do
+    should "strip the version from the license name" do
+      expected = "GNU Affero General Public License"
+      assert_equal expected, Licensee::License.find("agpl-3.0").name_without_version
+      expected = "GNU General Public License"
+      assert_equal expected,  Licensee::License.find("gpl-2.0").name_without_version
+      assert_equal expected,  Licensee::License.find("gpl-3.0").name_without_version
+    end
+
+    should "know if the license contains the name without version" do
+      refute Licensee::License.find("cc0-1.0").body_includes_name?
+      assert Licensee::License.find("agpl-3.0").body_includes_name?
+    end
+
+    should "know if the license contains the nickname" do
+      refute Licensee::License.find("mit").body_includes_nickname?
+      assert Licensee::License.find("apache-2.0").body_includes_nickname?
+    end
+
+    Licensee.licenses.each do |license|
+      should "strip the version number from the #{license.name} license" do
+        assert license.name_without_version
+      end
+    end
   end
 
   describe "class methods" do

--- a/test/test_licensee_project.rb
+++ b/test/test_licensee_project.rb
@@ -68,6 +68,10 @@ class TestLicenseeProject < Minitest::Test
     end
   end
 
+  should "detect the MIT license even with the title removed" do
+    verify_license_file fixture_path("mit-without-title/mit.txt")
+  end
+
   describe "packages" do
 
     def setup


### PR DESCRIPTION
Fixes https://github.com/benbalter/licensee/issues/50.

```
script/git-repo https://github.com/evan/memcached
Unknown
```

(We don't vendor the AFL)

As an added bonus, it actually speed things up a bit by letting us bail early.

The risk here, is a heavily modified license that would require us to go as far down the Matcher list as the Levenshtein matcher, may not have the license title (e.g., in the case of MIT) in which case we'd raise a false negative, but would like to try it in the wild a bit first to see how much that impacts things.

/cc @bkeepers