### PR TITLE
Fix for rewrapped MIT with no title

### DIFF
--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -39,6 +39,10 @@ class Licensee
 
     HIDDEN_LICENSES = %w[other no-license]
 
+    # Licenses that technically contain the license name or nickname
+    # But we are so short that GitMatcher may not catch if rewrapped
+    BODY_INCLUDES_WHITELIST = %w[mit]
+
     include Licensee::ContentHelper
 
     def initialize(key)
@@ -129,10 +133,12 @@ class Licensee
     end
 
     def body_includes_name?
+      return false if BODY_INCLUDES_WHITELIST.include?(key)
       @body_includes_name ||= body_normalized.include?(name_without_version.downcase)
     end
 
     def body_includes_nickname?
+      return false if BODY_INCLUDES_WHITELIST.include?(key)
       @body_includes_nickname ||= !!(nickname && body_normalized.include?(nickname.downcase))
     end
 

--- a/test/fixtures/mit-without-title-rewrapped/mit.txt
+++ b/test/fixtures/mit-without-title-rewrapped/mit.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Ben Balter
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/test/test_licensee_copyright_matcher.rb
+++ b/test/test_licensee_copyright_matcher.rb
@@ -51,4 +51,11 @@ class TestLicenseeCopyrightMatcher < Minitest::Test
     file = Licensee::ProjectFile.new(blob, "LICENSE")
     assert_equal "no-license", Licensee::CopyrightMatcher.match(file).key
   end
+
+  should "match comma, separated dates" do
+    text = "Copyright (c) 2003, 2004 Ben Balter"
+    blob = FakeBlob.new(text)
+    file = Licensee::ProjectFile.new(blob, "LICENSE")
+    assert_equal "no-license", Licensee::CopyrightMatcher.match(file).key
+  end
  end

--- a/test/test_licensee_project.rb
+++ b/test/test_licensee_project.rb
@@ -68,9 +68,16 @@ class TestLicenseeProject < Minitest::Test
     end
   end
 
-  should "detect the MIT license even with the title removed" do
-    verify_license_file fixture_path("mit-without-title/mit.txt")
+  describe "mit license with title removed" do
+    should "detect the MIT license" do
+      verify_license_file fixture_path("mit-without-title/mit.txt")
+    end
+
+    should "should detect the MIT license when rewrapped" do
+      verify_license_file fixture_path("mit-without-title-rewrapped/mit.txt")
+    end
   end
+
 
   describe "packages" do
 


### PR DESCRIPTION
Fixes #53.

For background: The MIT license traditionally doesn't have a title. cal.com added it so that it was more easily identified. That means that if a non-titled rewrapped license, the GitMatcher isn't going to catch it, and after #51, it won't hit Levenshtein.