### PR TITLE
WIP: Add AFL license

### DIFF
--- a/lib/licensee/matchers/dice_matcher.rb
+++ b/lib/licensee/matchers/dice_matcher.rb
@@ -9,9 +9,7 @@ class Licensee
       # than the confidence threshold
       def match
         return @match if defined? @match
-        @match = potential_licenses.find do |license|
-          similarity(license) >= Licensee.confidence_threshold
-        end
+        @match = matches.empty? ? nil : matches.max_by { |l, sim| sim }[0] 
       end
 
       # Sort all licenses, in decending order, by difference in
@@ -51,6 +49,12 @@ class Licensee
         overlap = (@file.wordset & license.wordset).size
         total = @file.wordset.size + license.wordset.size
         100.0 * (overlap * 2.0 / total)
+      end
+
+      # Return an array of arrays in the form of [license, similiarity]
+      def matches
+        matches = potential_licenses.map { |license| [license, similarity(license)] }
+        matches.select { |license, similarity| similarity >= Licensee.confidence_threshold }
       end
     end
   end

--- a/lib/licensee/matchers/dice_matcher.rb
+++ b/lib/licensee/matchers/dice_matcher.rb
@@ -9,7 +9,17 @@ class Licensee
       # than the confidence threshold
       def match
         return @match if defined? @match
-        @match = matches.empty? ? nil : matches.max_by { |l, sim| sim }[0] 
+        matches = potential_licenses.map do |license|
+          if (sim = similarity(license)) >= Licensee.confidence_threshold
+            [license, sim]
+          end
+        end
+        matches.compact!
+        @match = if matches.empty?
+          nil
+        else
+          matches.max_by { |l, sim| sim }.first
+        end
       end
 
       # Sort all licenses, in decending order, by difference in
@@ -49,12 +59,6 @@ class Licensee
         overlap = (@file.wordset & license.wordset).size
         total = @file.wordset.size + license.wordset.size
         100.0 * (overlap * 2.0 / total)
-      end
-
-      # Return an array of arrays in the form of [license, similiarity]
-      def matches
-        matches = potential_licenses.map { |license| [license, similarity(license)] }
-        matches.select { |license, similarity| similarity >= Licensee.confidence_threshold }
       end
     end
   end

--- a/test/test_licensee.rb
+++ b/test/test_licensee.rb
@@ -4,7 +4,7 @@ class TestLicensee < Minitest::Test
   should "know the licenses" do
     assert_equal Array, Licensee.licenses.class
     assert_equal 15, Licensee.licenses.size
-    assert_equal 23, Licensee.licenses(:hidden => true).size
+    assert_equal 24, Licensee.licenses(:hidden => true).size
     assert_equal Licensee::License, Licensee.licenses.first.class
   end
 

--- a/test/test_licensee_license.rb
+++ b/test/test_licensee_license.rb
@@ -122,13 +122,13 @@ class TestLicenseeLicense < Minitest::Test
   describe "class methods" do
     should "know license names" do
       assert_equal Array, Licensee::License.keys.class
-      assert_equal 23, Licensee::License.keys.size
+      assert_equal 24, Licensee::License.keys.size
     end
 
     should "load the licenses" do
       assert_equal Array, Licensee::License.all.class
       assert_equal 15, Licensee::License.all.size
-      assert_equal 23, Licensee::License.all(:hidden => true).size
+      assert_equal 24, Licensee::License.all(:hidden => true).size
       assert_equal Licensee::License, Licensee::License.all.first.class
     end
 

--- a/vendor/choosealicense.com/_licenses/afl-3.0.txt
+++ b/vendor/choosealicense.com/_licenses/afl-3.0.txt
@@ -1,0 +1,69 @@
+---
+title: Academic Free License v3.0
+source: http://opensource.org/licenses/afl-3.0
+
+description: The Academic Free License is a variant of the Open Source License that does not require that the source code of derivative works be disclosed. It contains explicit copyright and patent grants and reserves trademark rights in the author.
+
+hidden: true
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Files licensed under OSL 3.0 must also include the notice "Licensed under the Academic Free License version 3.0" adjacent to the copyright notice.
+
+required:
+  - include-copyright
+
+permitted:
+  - commercial-use
+  - modifications
+  - distribution
+  - sublicense
+  - private-use
+  - patent-grant
+
+forbidden:
+  - trademark-use
+  - no-liability
+
+---
+Academic Free License (“AFL”) v. 3.0
+
+This Academic Free License (the "License") applies to any original work of authorship (the "Original Work") whose owner (the "Licensor") has placed the following licensing notice adjacent to the copyright notice for the Original Work:
+
+Licensed under the Academic Free License version 3.0
+
+1) Grant of Copyright License. Licensor grants You a worldwide, royalty-free, non-exclusive, sublicensable license, for the duration of the copyright, to do the following:
+
+  a) to reproduce the Original Work in copies, either alone or as part of a collective work;
+  b) to translate, adapt, alter, transform, modify, or arrange the Original Work, thereby creating derivative works ("Derivative Works") based upon the Original Work;
+  c) to distribute or communicate copies of the Original Work and Derivative Works to the public, under any license of your choice that does not contradict the terms and conditions, including Licensor’s reserved rights and remedies, in this Academic Free License;
+  d) to perform the Original Work publicly; and
+  e) to display the Original Work publicly.
+
+2) Grant of Patent License. Licensor grants You a worldwide, royalty-free, non-exclusive, sublicensable license, under patent claims owned or controlled by the Licensor that are embodied in the Original Work as furnished by the Licensor, for the duration of the patents, to make, use, sell, offer for sale, have made, and import the Original Work and Derivative Works.
+
+3) Grant of Source Code License. The term "Source Code" means the preferred form of the Original Work for making modifications to it and all available documentation describing how to modify the Original Work. Licensor agrees to provide a machine-readable copy of the Source Code of the Original Work along with each copy of the Original Work that Licensor distributes. Licensor reserves the right to satisfy this obligation by placing a machine-readable copy of the Source Code in an information repository reasonably calculated to permit inexpensive and convenient access by You for as long as Licensor continues to distribute the Original Work.
+
+4) Exclusions From License Grant. Neither the names of Licensor, nor the names of any contributors to the Original Work, nor any of their trademarks or service marks, may be used to endorse or promote products derived from this Original Work without express prior permission of the Licensor. Except as expressly stated herein, nothing in this License grants any license to Licensor’s trademarks, copyrights, patents, trade secrets or any other intellectual property. No patent license is granted to make, use, sell, offer for sale, have made, or import embodiments of any patent claims other than the licensed claims defined in Section 2. No license is granted to the trademarks of Licensor even if such marks are included in the Original Work. Nothing in this License shall be interpreted to prohibit Licensor from licensing under terms different from this License any Original Work that Licensor otherwise would have a right to license.
+
+5) External Deployment. The term "External Deployment" means the use, distribution, or communication of the Original Work or Derivative Works in any way such that the Original Work or Derivative Works may be used by anyone other than You, whether those works are distributed or communicated to those persons or made available as an application intended for use over a network. As an express condition for the grants of license hereunder, You must treat any External Deployment by You of the Original Work or a Derivative Work as a distribution under section 1(c).
+
+6) Attribution Rights. You must retain, in the Source Code of any Derivative Works that You create, all copyright, patent, or trademark notices from the Source Code of the Original Work, as well as any notices of licensing and any descriptive text identified therein as an "Attribution Notice." You must cause the Source Code for any Derivative Works that You create to carry a prominent Attribution Notice reasonably calculated to inform recipients that You have modified the Original Work.
+
+7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that the copyright in and to the Original Work and the patent rights granted herein by Licensor are owned by the Licensor or are sublicensed to You under the terms of this License with the permission of the contributor(s) of those copyrights and patent rights. Except as expressly stated in the immediately preceding sentence, the Original Work is provided under this License on an "AS IS" BASIS and WITHOUT WARRANTY, either express or implied, including, without limitation, the warranties of non-infringement, merchantability or fitness for a particular purpose. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH YOU. This DISCLAIMER OF WARRANTY constitutes an essential part of this License. No license to the Original Work is granted by this License except under this disclaimer.
+
+8) Limitation of Liability. Under no circumstances and under no legal theory, whether in tort (including negligence), contract, or otherwise, shall the Licensor be liable to anyone for any indirect, special, incidental, or consequential damages of any character arising as a result of this License or the use of the Original Work including, without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses. This limitation of liability shall not apply to the extent applicable law prohibits such limitation.
+
+9) Acceptance and Termination. If, at any time, You expressly assented to this License, that assent indicates your clear and irrevocable acceptance of this License and all of its terms and conditions. If You distribute or communicate copies of the Original Work or a Derivative Work, You must make a reasonable effort under the circumstances to obtain the express assent of recipients to the terms of this License. This License conditions your rights to undertake the activities listed in Section 1, including your right to create Derivative Works based upon the Original Work, and doing so without honoring these terms and conditions is prohibited by copyright law and international treaty. Nothing in this License is intended to affect copyright exceptions and limitations (including “fair use” or “fair dealing”). This License shall terminate immediately and You may no longer exercise any of the rights granted to You by this License upon your failure to honor the conditions in Section 1(c).
+
+10) Termination for Patent Action. This License shall terminate automatically and You may no longer exercise any of the rights granted to You by this License as of the date You commence an action, including a cross-claim or counterclaim, against Licensor or any licensee alleging that the Original Work infringes a patent. This termination provision shall not apply for an action alleging patent infringement by combinations of the Original Work with other software or hardware.
+
+11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this License may be brought only in the courts of a jurisdiction wherein the Licensor resides or in which Licensor conducts its primary business, and under the laws of that jurisdiction excluding its conflict-of-law provisions. The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded. Any use of the Original Work outside the scope of this License or after its termination shall be subject to the requirements and penalties of copyright or patent law in the appropriate jurisdiction. This section shall survive the termination of this License.
+
+12) Attorneys’ Fees. In any action to enforce the terms of this License or seeking damages relating thereto, the prevailing party shall be entitled to recover its costs and expenses, including, without limitation, reasonable attorneys' fees and costs incurred in connection with such action, including any appeal of such action. This section shall survive the termination of this License.
+
+13) Miscellaneous. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.
+
+14) Definition of "You" in This License. "You" throughout this License, whether in upper or lower case, means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License. For legal entities, "You" includes any entity that controls, is controlled by, or is under common control with you. For purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+15) Right to Use. You may use the Original Work in all ways not otherwise restricted or conditioned by this License or by law, and Licensor promises not to interfere with or be responsible for such uses by You.
+
+16) Modification of This License. This License is Copyright © 2005 Lawrence Rosen. Permission is granted to copy, distribute, or communicate this License without modification. Nothing in this License permits You to modify this License as applied to the Original Work or to Derivative Works. However, You may modify the text of this License and copy, distribute or communicate your modified version (the "Modified License") and apply it to other original works of authorship subject to the following conditions: (i) You may not indicate in any way that your Modified License is the "Academic Free License" or "AFL" and you may not use those names in the name of your Modified License; (ii) You must replace the notice specified in the first paragraph above with the notice "Licensed under <insert your license name here>" or with a notice of your own that is not confusingly similar to the notice in this License; and (iii) You may not claim that your original works are open source software unless your Modified License has been approved by Open Source Initiative (OSI) and You comply with its license review and certification process.

--- a/vendor/choosealicense.com/_licenses/isc.txt
+++ b/vendor/choosealicense.com/_licenses/isc.txt
@@ -6,7 +6,7 @@ source: http://opensource.org/licenses/isc-license
 
 description: A permissive license lets people do anything with your code with proper attribution and without warranty. The ISC license is functionally equivalent to the <a href="/licenses/bsd">BSD 2-Clause</a> and <a href="/licenses/mit">MIT</a> licenses, removing some language that is no longer necessary.
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.  [email] is optional but recommended.
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 required:
   - include-copyright
@@ -23,7 +23,7 @@ forbidden:
 
 ---
 
-Copyright (c) [year], [fullname] <[email]>
+Copyright (c) [year], [fullname]
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
WIP, because we're having issues differentiating from OSL, which appears 98% similar:

```
  1) Failure:
TestLicenseeVendor#test_: different line lengths should detect the /Users/benbalter/projects/licensee/vendor/choosealicense.com/_licenses/afl-3.0.txt license.  [/Users/benbalter/projects/licensee/test/functions.rb:42]:
expeceted afl-3.0 but got osl-3.0 for .match. Confidence: 98.46827133479212. Method: Licensee::Matchers::Dice.
Expected: "afl-3.0"
  Actual: "osl-3.0"


  2) Failure:
TestLicenseeVendor#test_: different line lengths when modified should detect the /Users/benbalter/projects/licensee/vendor/choosealicense.com/_licenses/afl-3.0.txt license.  [/Users/benbalter/projects/licensee/test/functions.rb:42]:
expeceted afl-3.0 but got osl-3.0 for .match. Confidence: 98.46827133479212. Method: Licensee::Matchers::Dice.
Expected: "afl-3.0"
  Actual: "osl-3.0"
```

For different line lengths, the exact matcher should match. Going to investigate.

For the modified + different line lengths, given the speed, perhaps we can score all potential licenses and choose the best?

/cc @bkeepers, @vmg 