### PR TITLE
More usage info for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,19 @@ _Special thanks to [@vmg](https://github.com/vmg) for his Git and algorithmic pr
 ## Installation
 `gem install licensee` or add `gem 'licensee'` to your project's `Gemfile`.
 
-## Usage
+## Command line usage
+1. `cd` into a project directory
+2. execute the `licensee` command
+
+You'll get an output that looks like:
+
+```
+License: MIT
+Confidence: 98.42%
+Matcher: Licensee::GitMatcher
+```
+
+## License API
 
 ```ruby
 license = Licensee.license "/path/to/a/project"
@@ -41,16 +53,21 @@ license.meta["permitted"]
 => ["commercial-use","modifications","distribution","sublicense","private-use"]
 ```
 
-## Command line usage
-1. `cd` into a project directory
-2. execute the `licensee` command
+## More API
+You can gather more information by working with the project object, and the top level Licensee class. 
 
-You'll get an output that looks like:
+```ruby
+ Licensee::VERSION                                 # The Licensee version
+ Licensee.licenses                                 # All the licenses Licensee knows about
 
-```
-License: MIT
-Confidence: 98.42%
-Matcher: Licensee::GitMatcher
+ project=Licensee.project "/path/to/a/project"     # Get a Project (Git checkout or just local Filesystem) (post 6.0.0)
+
+ project.license                                   # The matched license
+ project.matched_file                              # Object for the particular file containing the apparent license
+ project.matched_file.filename                     #   Its filename
+ project.matched_file.confidence                   #   The confidence level in the license matching
+ project.matched_file.content                      #   The content of your license file
+ project.license.content                           # The Open Source License text it matched against
 ```
 
 ## What it looks at


### PR DESCRIPTION
If useful - added more info on how to call licensee. Also moved the command line usage above the library usage as it gets a user trying out the library quicker