### PR TITLE
Expose license hash

### DIFF
--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -2,8 +2,13 @@ require_relative "licensee/version"
 require_relative "licensee/content_helper"
 require_relative "licensee/license"
 require_relative "licensee/project"
-require_relative "licensee/project_file"
 
+# Project files
+require_relative "licensee/project_file"
+require_relative "licensee/project_files/license_file.rb"
+require_relative "licensee/project_files/package_info.rb"
+
+# Matchers
 require_relative "licensee/matchers/exact_matcher"
 require_relative "licensee/matchers/copyright_matcher"
 require_relative "licensee/matchers/dice_matcher"

--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -1,13 +1,21 @@
 require 'set'
+require 'digest'
 
 class Licensee
   module ContentHelper
+
+    DIGEST = Digest::SHA1
+
     def create_word_set(content)
       return unless content
       content = content.dup
       content.downcase!
       content.gsub!(/^#{Matchers::Copyright::REGEX}$/i, '')
       content.scan(/[\w']+/).to_set
+    end
+
+    def hash
+      @hash ||= DIGEST.hexdigest(content)
     end
   end
 end

--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -6,16 +6,21 @@ class Licensee
 
     DIGEST = Digest::SHA1
 
-    def create_word_set(content)
-      return unless content
-      content = content.dup
-      content.downcase!
-      content.gsub!(/^#{Matchers::Copyright::REGEX}$/i, '')
-      content.scan(/[\w']+/).to_set
+    def wordset
+      @wordset ||= content_normalized.scan(/[\w']+/).to_set if content_normalized
     end
 
     def hash
-      @hash ||= DIGEST.hexdigest(content)
+      @hash ||= DIGEST.hexdigest content_normalized
+    end
+
+    def content_normalized
+      return unless content
+      @content_normalized ||= begin
+        content_normalized = content.downcase.strip
+        content_normalized.gsub!(/^#{Matchers::Copyright::REGEX}$/i, '')
+        content_normalized.gsub("\n", " ").squeeze(" ")
+      end
     end
   end
 end

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -68,17 +68,6 @@ class Licensee
       @path ||= File.expand_path "#{@key}.txt", Licensee::License.license_dir
     end
 
-    # Raw content of license file, including YAML front matter
-    def content
-      @content ||= if File.exists?(path)
-        File.open(path).read
-      elsif key == "other" # A pseudo-license with no content
-        nil
-      else
-        raise Licensee::InvalidLicense, "'#{key}' is not a valid license key"
-      end
-    end
-
     # License metadata from YAML front matter
     def meta
       @meta ||= if parts && parts[1]
@@ -115,15 +104,12 @@ class Licensee
     end
 
     # The license body (e.g., contents - frontmatter)
-    def body
-      @body ||= parts[2] if parts && parts[2]
+    def content
+      @content ||= parts[2] if parts && parts[2]
     end
-    alias_method :to_s, :body
-    alias_method :text, :body
-
-    def wordset
-      @wordset ||= create_word_set(body)
-    end
+    alias_method :to_s, :content
+    alias_method :text, :content
+    alias_method :body, :content
 
     def inspect
       "#<Licensee::License key=\"#{key}\" name=\"#{name}\">"
@@ -138,8 +124,20 @@ class Licensee
     end
 
     private
+
+    # Raw content of license file, including YAML front matter
+    def raw_content
+      @raw_content ||= if File.exists?(path)
+        File.open(path).read
+      elsif key == "other" # A pseudo-license with no content
+        nil
+      else
+        raise Licensee::InvalidLicense, "'#{key}' is not a valid license key"
+      end
+    end
+
     def parts
-      @parts ||= content.match(/\A(---\n.*\n---\n+)?(.*)/m).to_a if content
+      @parts ||= raw_content.match(/\A(---\n.*\n---\n+)?(.*)/m).to_a if raw_content
     end
   end
 end

--- a/lib/licensee/project_file.rb
+++ b/lib/licensee/project_file.rb
@@ -1,7 +1,7 @@
-# encoding=utf-8
 class Licensee
   class Project
     private
+
     class File
       attr_reader :content, :filename
 
@@ -26,53 +26,6 @@ class Licensee
 
       alias_method :match, :license
       alias_method :path, :filename
-    end
-
-    public
-    class LicenseFile < File
-      include Licensee::ContentHelper
-
-      def possible_matchers
-        [Matchers::Copyright, Matchers::Exact, Matchers::Dice]
-      end
-
-      def wordset
-        @wordset ||= create_word_set(content)
-      end
-
-      def attribution
-        matches = /^#{Matchers::Copyright::REGEX}$/i.match(content)
-        matches[0].strip if matches
-      end
-
-      def self.name_score(filename)
-        return 1.0 if filename =~ /\A(un)?licen[sc]e\z/i
-        return 0.9 if filename =~ /\A(un)?licen[sc]e\.(md|markdown|txt)\z/i
-        return 0.8 if filename =~ /\Acopy(ing|right)(\.[^.]+)?\z/i
-        return 0.7 if filename =~ /\A(un)?licen[sc]e\.[^.]+\z/i
-        return 0.5 if filename =~ /licen[sc]e/i
-        return 0.0
-      end
-    end
-
-    class PackageInfo < File
-      def possible_matchers
-        case ::File.extname(filename)
-        when ".gemspec"
-          [Matchers::Gemspec]
-        when ".json"
-          [Matchers::NpmBower]
-        else
-          []
-        end
-      end
-
-      def self.name_score(filename)
-        return 1.0  if ::File.extname(filename) == ".gemspec"
-        return 1.0  if filename == "package.json"
-        return 0.75 if filename == "bower.json"
-        return 0.0
-      end
     end
   end
 end

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -1,0 +1,29 @@
+class Licensee
+  class Project
+    class LicenseFile < Licensee::Project::File
+      include Licensee::ContentHelper
+
+      def possible_matchers
+        [Matchers::Copyright, Matchers::Exact, Matchers::Dice]
+      end
+
+      def wordset
+        @wordset ||= create_word_set(content)
+      end
+
+      def attribution
+        matches = /^#{Matchers::Copyright::REGEX}$/i.match(content)
+        matches[0].strip if matches
+      end
+
+      def self.name_score(filename)
+        return 1.0 if filename =~ /\A(un)?licen[sc]e\z/i
+        return 0.9 if filename =~ /\A(un)?licen[sc]e\.(md|markdown|txt)\z/i
+        return 0.8 if filename =~ /\Acopy(ing|right)(\.[^.]+)?\z/i
+        return 0.7 if filename =~ /\A(un)?licen[sc]e\.[^.]+\z/i
+        return 0.5 if filename =~ /licen[sc]e/i
+        return 0.0
+      end
+    end
+  end
+end

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -6,11 +6,7 @@ class Licensee
       def possible_matchers
         [Matchers::Copyright, Matchers::Exact, Matchers::Dice]
       end
-
-      def wordset
-        @wordset ||= create_word_set(content)
-      end
-
+      
       def attribution
         matches = /^#{Matchers::Copyright::REGEX}$/i.match(content)
         matches[0].strip if matches

--- a/lib/licensee/project_files/package_info.rb
+++ b/lib/licensee/project_files/package_info.rb
@@ -1,0 +1,23 @@
+class Licensee
+  class Project
+    class PackageInfo < Licensee::Project::File
+      def possible_matchers
+        case ::File.extname(filename)
+        when ".gemspec"
+          [Matchers::Gemspec]
+        when ".json"
+          [Matchers::NpmBower]
+        else
+          []
+        end
+      end
+
+      def self.name_score(filename)
+        return 1.0  if ::File.extname(filename) == ".gemspec"
+        return 1.0  if filename == "package.json"
+        return 0.75 if filename == "bower.json"
+        return 0.0
+      end
+    end
+  end
+end

--- a/test/test_licensee_license.rb
+++ b/test/test_licensee_license.rb
@@ -103,6 +103,10 @@ class TestLicenseeLicense < Minitest::Test
     refute license.featured?
   end
 
+  should "know the license hash" do
+    assert_equal "a191511c2825110c81001e1bc286f669b718f27f", @license.hash
+  end
+
   describe "name without version" do
     should "strip the version from the license name" do
       expected = "GNU Affero General Public License"

--- a/test/test_licensee_license.rb
+++ b/test/test_licensee_license.rb
@@ -14,7 +14,7 @@ class TestLicenseeLicense < Minitest::Test
   should "read the license body if it contains `---`" do
     license = Licensee::License.new "MIT"
     content = "---\nfoo: bar\n---\nSome license\n---------\nsome text\n"
-    license.instance_variable_set(:@content, content)
+    license.instance_variable_set(:@raw_content, content)
     assert_equal "Some license\n---------\nsome text\n", license.body
   end
 
@@ -104,7 +104,7 @@ class TestLicenseeLicense < Minitest::Test
   end
 
   should "know the license hash" do
-    assert_equal "a191511c2825110c81001e1bc286f669b718f27f", @license.hash
+    assert_equal "fb278496ea4663dfcf41ed672eb7e56eb70de798", @license.hash
   end
 
   describe "name without version" do

--- a/test/test_licensee_license_file.rb
+++ b/test/test_licensee_license_file.rb
@@ -1,0 +1,56 @@
+require 'helper'
+
+class TestLicenseeLicenseFile < Minitest::Test
+  def setup
+    @repo = Rugged::Repository.new(fixture_path("licenses.git"))
+    blob, _ = Rugged::Blob.to_buffer(@repo, 'bcb552d06d9cf1cd4c048a6d3bf716849c2216cc')
+    @file = Licensee::Project::LicenseFile.new(blob)
+  end
+
+  context "content" do
+    should "parse the attribution" do
+      assert_equal "Copyright (c) 2014 Ben Balter", @file.attribution
+    end
+
+    should "not choke on non-UTF-8 licenses" do
+      text = "\x91License\x93".force_encoding('windows-1251')
+      file = Licensee::Project::LicenseFile.new(text)
+      assert_equal nil, file.attribution
+    end
+
+    should "create the wordset" do
+      assert_equal 93, @file.wordset.count
+      assert_equal "the", @file.wordset.first
+    end
+
+    should "create the hash" do
+      assert_equal "44a042145f04777012c38c161533ca67a73dfc1e", @file.hash
+    end
+  end
+
+  context "license filename scoring" do
+    EXPECTATIONS = {
+      "license"            => 1.0,
+      "LICENCE"            => 1.0,
+      "unLICENSE"          => 1.0,
+      "unlicence"          => 1.0,
+      "license.md"         => 0.9,
+      "LICENSE.md"         => 0.9,
+      "license.txt"        => 0.9,
+      "COPYING"            => 0.8,
+      "copyRIGHT"          => 0.8,
+      "COPYRIGHT.txt"      => 0.8,
+      "LICENSE.php"        => 0.7,
+      "LICENSE-MIT"        => 0.5,
+      "MIT-LICENSE.txt"    => 0.5,
+      "mit-license-foo.md" => 0.5,
+      "README.txt"         => 0.0
+    }
+
+    EXPECTATIONS.each do |filename, expected|
+      should "score a license named `#{filename}` as `#{expected}`" do
+        assert_equal expected, Licensee::Project::LicenseFile.name_score(filename)
+      end
+    end
+  end
+end

--- a/test/test_licensee_license_file.rb
+++ b/test/test_licensee_license_file.rb
@@ -24,7 +24,7 @@ class TestLicenseeLicenseFile < Minitest::Test
     end
 
     should "create the hash" do
-      assert_equal "44a042145f04777012c38c161533ca67a73dfc1e", @file.hash
+      assert_equal "fb278496ea4663dfcf41ed672eb7e56eb70de798", @file.hash
     end
   end
 

--- a/test/test_licensee_package_info.rb
+++ b/test/test_licensee_package_info.rb
@@ -1,0 +1,18 @@
+require 'helper'
+
+class TestLicenseePackageInfo < Minitest::Test
+  context "license filename scoring" do
+    EXPECTATIONS = {
+      "licensee.gemspec"     => 1.0,
+      "package.json" => 1.0,
+      "bower.json"   => 0.75,
+      "README.md"    => 0.0
+    }
+
+    EXPECTATIONS.each do |filename, expected|
+      should "score a license named `#{filename}` as `#{expected}`" do
+        assert_equal expected, Licensee::Project::PackageInfo.name_score(filename)
+      end
+    end
+  end
+end

--- a/test/test_licensee_package_info.rb
+++ b/test/test_licensee_package_info.rb
@@ -3,10 +3,10 @@ require 'helper'
 class TestLicenseePackageInfo < Minitest::Test
   context "license filename scoring" do
     EXPECTATIONS = {
-      "licensee.gemspec"     => 1.0,
-      "package.json" => 1.0,
-      "bower.json"   => 0.75,
-      "README.md"    => 0.0
+      "licensee.gemspec" => 1.0,
+      "package.json"     => 1.0,
+      "bower.json"       => 0.75,
+      "README.md"        => 0.0
     }
 
     EXPECTATIONS.each do |filename, expected|

--- a/test/test_licensee_project_file.rb
+++ b/test/test_licensee_project_file.rb
@@ -21,40 +21,4 @@ class TestLicenseeProjectFile < Minitest::Test
   should "calculate confidence" do
     assert_equal 100, @file.confidence
   end
-
-  should "parse the attribution" do
-    assert_equal "Copyright (c) 2014 Ben Balter", @file.attribution
-  end
-
-  should "not choke on non-UTF-8 licenses" do
-    text = "\x91License\x93".force_encoding('windows-1251')
-    file = Licensee::Project::LicenseFile.new(text)
-    assert_equal nil, file.attribution
-  end
-
-  context "license filename scoring" do
-    EXPECTATIONS = {
-      "license"            => 1.0,
-      "LICENCE"            => 1.0,
-      "unLICENSE"          => 1.0,
-      "unlicence"          => 1.0,
-      "license.md"         => 0.9,
-      "LICENSE.md"         => 0.9,
-      "license.txt"        => 0.9,
-      "COPYING"            => 0.8,
-      "copyRIGHT"          => 0.8,
-      "COPYRIGHT.txt"      => 0.8,
-      "LICENSE.php"        => 0.7,
-      "LICENSE-MIT"        => 0.5,
-      "MIT-LICENSE.txt"    => 0.5,
-      "mit-license-foo.md" => 0.5,
-      "README.txt"         => 0.0
-    }
-
-    EXPECTATIONS.each do |filename, expected|
-      should "score a license named `#{filename}` as `#{expected}`" do
-        assert_equal expected, Licensee::Project::LicenseFile.name_score(filename)
-      end
-    end
-  end
 end


### PR DESCRIPTION
This pull request exposes `License#hash` and `LicenseFile#hash` methods for identifying and comparing non-standard licenses.

This is implemented by adding `hash` and `content_normalized` methods to `ContentHelper`, which simply strip whitespace and calculates the SHA256 hash of the file's content. I'm not beholden to SHA256, if folks like @vmg have strong opinions for one hashing algorithm over another. Given the use case, it doesn't need to be cryptographic, but we'd want it to be fast and unique.

This isn't used for the built in license detection. The use case in mind here is the one described in #67. Where Licensee fails to detect a license, the hash could be used by end users to identify identical (once normalized, including removing copyright information) but unknown licenses.

I also moved `LicenseFile` and `ProjectInfo` into their own files, to make it a bit easier to test things more granularly, and standardized `License` and `LicenseFile` to use `#content` (rather than `License` using `#body` before) to describe the contents of the license (but aliased to `#body` to preserve backwards compatibility).

Fixes #67