### PR TITLE
Make licensee a Module, not a Class

### DIFF
--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -9,8 +9,8 @@ require_relative "licensee/projects/fs_project"
 
 # Project files
 require_relative "licensee/project_file"
-require_relative "licensee/project_files/license_file.rb"
-require_relative "licensee/project_files/package_info.rb"
+require_relative "licensee/project_files/license_file"
+require_relative "licensee/project_files/package_info"
 
 # Matchers
 require_relative "licensee/matchers/exact_matcher"
@@ -20,7 +20,7 @@ require_relative "licensee/matchers/package_matcher"
 require_relative "licensee/matchers/gemspec_matcher"
 require_relative "licensee/matchers/npm_bower_matcher"
 
-class Licensee
+module Licensee
   # Over which percent is a match considered a match by default
   CONFIDENCE_THRESHOLD = 90
 

--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -1,7 +1,7 @@
 require 'set'
 require 'digest'
 
-class Licensee
+module Licensee
   module ContentHelper
 
     DIGEST = Digest::SHA1

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -1,7 +1,7 @@
 require 'uri'
 require 'yaml'
 
-class Licensee
+module Licensee
   class InvalidLicense < ArgumentError; end
   class License
 

--- a/lib/licensee/matchers/copyright_matcher.rb
+++ b/lib/licensee/matchers/copyright_matcher.rb
@@ -1,5 +1,5 @@
 # encoding=utf-8
-class Licensee
+module Licensee
   module Matchers
     class Copyright
       REGEX = /\s*Copyright (©|\(c\)|\xC2\xA9)? ?(\d{4}|\[year\])(.*)?\s*/i
@@ -11,7 +11,7 @@ class Licensee
       def match
         # Note: must use content, and not content_normalized here
         if @file.content.strip =~ /\A#{REGEX}\z/i
-          Licensee::License.find("no-license") 
+          Licensee::License.find("no-license")
         end
       rescue
         nil

--- a/lib/licensee/matchers/dice_matcher.rb
+++ b/lib/licensee/matchers/dice_matcher.rb
@@ -1,4 +1,4 @@
-class Licensee
+module Licensee
   module Matchers
     class Dice
       def initialize(file)

--- a/lib/licensee/matchers/exact_matcher.rb
+++ b/lib/licensee/matchers/exact_matcher.rb
@@ -1,4 +1,4 @@
-class Licensee
+module Licensee
   module Matchers
     class Exact
       def initialize(file)

--- a/lib/licensee/matchers/gemspec_matcher.rb
+++ b/lib/licensee/matchers/gemspec_matcher.rb
@@ -1,4 +1,4 @@
-class Licensee
+module Licensee
   module Matchers
     class Gemspec < Package
       # We definitely don't want to be evaling arbitrary Gemspec files

--- a/lib/licensee/matchers/npm_bower_matcher.rb
+++ b/lib/licensee/matchers/npm_bower_matcher.rb
@@ -1,4 +1,4 @@
-class Licensee
+module Licensee
   module Matchers
     class NpmBower < Package
       # While we could parse the package.json or bower.json file, prefer

--- a/lib/licensee/matchers/package_matcher.rb
+++ b/lib/licensee/matchers/package_matcher.rb
@@ -1,4 +1,4 @@
-class Licensee
+module Licensee
   module Matchers
     class Package
       def initialize(file)

--- a/lib/licensee/project.rb
+++ b/lib/licensee/project.rb
@@ -1,6 +1,6 @@
 require 'rugged'
 
-class Licensee
+module Licensee
   private
   class Project
     def initialize(detect_packages)

--- a/lib/licensee/project_file.rb
+++ b/lib/licensee/project_file.rb
@@ -1,4 +1,4 @@
-class Licensee
+module Licensee
   class Project
     private
 

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -1,4 +1,4 @@
-class Licensee
+module Licensee
   class Project
     class LicenseFile < Licensee::Project::File
       include Licensee::ContentHelper
@@ -6,7 +6,7 @@ class Licensee
       def possible_matchers
         [Matchers::Copyright, Matchers::Exact, Matchers::Dice]
       end
-      
+
       def attribution
         matches = /^#{Matchers::Copyright::REGEX}$/i.match(content)
         matches[0].strip if matches

--- a/lib/licensee/project_files/package_info.rb
+++ b/lib/licensee/project_files/package_info.rb
@@ -1,4 +1,4 @@
-class Licensee
+module Licensee
   class Project
     class PackageInfo < Licensee::Project::File
       def possible_matchers

--- a/lib/licensee/projects/fs_project.rb
+++ b/lib/licensee/projects/fs_project.rb
@@ -1,7 +1,7 @@
 # Filesystem-based project
 #
 # Analyze a folder on the filesystem for license information
-class Licensee
+module Licensee
   class FSProject < Project
     attr_reader :path
 

--- a/lib/licensee/projects/git_project.rb
+++ b/lib/licensee/projects/git_project.rb
@@ -1,7 +1,7 @@
 # Git-based project
 #
 # analyze a given git repository for license information
-class Licensee
+module Licensee
   class GitProject < Licensee::Project
     attr_reader :repository, :revision
 

--- a/lib/licensee/version.rb
+++ b/lib/licensee/version.rb
@@ -1,3 +1,3 @@
-class Licensee
+module Licensee
   VERSION = "6.1.0"
 end


### PR DESCRIPTION
Because you never instantiate the top level class, it's just serves as a namespace for the other instantiated classes like Project and License.