### PR TITLE
WIP: Make rugged dependency optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ rvm:
 script: "script/cibuild"
 sudo: false
 cache: bundler
+env:
+  matrix:
+    - RUGGED=0
+    - RUGGED=1

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "https://rubygems.org"
 
 gemspec
+
+if ENV["RUGGED"] == "1"
+  gem 'rugged', "~> 0.23"
+end

--- a/bin/licensee
+++ b/bin/licensee
@@ -3,7 +3,7 @@ require_relative "../lib/licensee"
 
 path = ARGV[0] || Dir.pwd
 
-project = Licensee::GitProject.new(path, detect_packages: true, detect_readme: true)
+project = Licensee.project(path, detect_packages: true, detect_readme: true)
 file = project.matched_file
 
 if project.license_file

--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -21,6 +21,12 @@ require_relative "licensee/matchers/package_matcher"
 require_relative "licensee/matchers/gemspec_matcher"
 require_relative "licensee/matchers/npm_bower_matcher"
 
+begin
+  require 'rugged'
+rescue LoadError
+  puts "WARNING: Rugged not installed. Using file system method instead."
+end
+
 module Licensee
   # Over which percent is a match considered a match by default
   CONFIDENCE_THRESHOLD = 90
@@ -41,11 +47,11 @@ module Licensee
       Licensee.project(path).license
     end
 
-    def project(path)
+    def project(path, **args)
       begin
-        Licensee::GitProject.new(path)
+        Licensee::GitProject.new(path, args)
       rescue Licensee::GitProject::InvalidRepository
-        Licensee::FSProject.new(path)
+        Licensee::FSProject.new(path, args)
       end
     end
 

--- a/lib/licensee/project.rb
+++ b/lib/licensee/project.rb
@@ -1,5 +1,3 @@
-require 'rugged'
-
 module Licensee
   private
   class Project

--- a/lib/licensee/projects/git_project.rb
+++ b/lib/licensee/projects/git_project.rb
@@ -13,9 +13,11 @@ module Licensee
       else
         @repository = Rugged::Repository.new(repo)
       end
-
       @revision = revision
       super(**args)
+    rescue NameError => e
+      raise e unless e.message == "uninitialized constant Licensee::GitProject::Rugged"
+      raise InvalidRepository, "Rugged not initialized"
     rescue Rugged::RepositoryError
       raise InvalidRepository
     end

--- a/licensee.gemspec
+++ b/licensee.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |gem|
   gem.bindir = 'bin'
   gem.executables << 'licensee'
 
-  gem.add_dependency('rugged', '~> 0.23')
   gem.add_development_dependency('pry', '~> 0.9')
   gem.add_development_dependency('shoulda', '~> 3.5')
   gem.add_development_dependency('rake', '~> 10.3')

--- a/test/functions.rb
+++ b/test/functions.rb
@@ -53,3 +53,18 @@ def wrap(text, line_width=80)
   text.gsub! "[COPYRIGHT]", "\n#{copyright}\n" if copyright
   text.strip
 end
+
+def rugged?
+  ENV["RUGGED"] == "1"
+end
+
+def licenses_file
+  if rugged?
+    repo = Rugged::Repository.new(fixture_path("licenses.git"))
+    blob, _ = Rugged::Blob.to_buffer(repo, 'bcb552d06d9cf1cd4c048a6d3bf716849c2216cc')
+    Licensee::Project::LicenseFile.new(blob)
+  else
+    text = license_from_path Licensee::License.find("mit").path
+    Licensee::Project::LicenseFile.new(text)
+  end
+end

--- a/test/test_licensee.rb
+++ b/test/test_licensee.rb
@@ -9,11 +9,20 @@ class TestLicensee < Minitest::Test
   end
 
   should "detect a project's license" do
-    assert_equal "mit", Licensee.license(fixture_path("licenses.git")).key
+    fixture = "licenses"
+    fixture << ".git" if ENV["RUGGED"] == "1"
+    assert_equal "mit", Licensee.license(fixture_path(fixture)).key
   end
 
   should "init a project" do
-    assert_equal Licensee::GitProject, Licensee.project(fixture_path("licenses.git")).class
+    fixture = "licenses"
+    if rugged?
+      fixture << ".git"
+      expected = Licensee::GitProject
+    else
+      expected = Licensee::FSProject
+    end
+    assert_equal expected, Licensee.project(fixture_path(fixture)).class
   end
 
   context "confidence threshold" do

--- a/test/test_licensee.rb
+++ b/test/test_licensee.rb
@@ -10,7 +10,7 @@ class TestLicensee < Minitest::Test
 
   should "detect a project's license" do
     fixture = "licenses"
-    fixture << ".git" if ENV["RUGGED"] == "1"
+    fixture << ".git" if rugged?
     assert_equal "mit", Licensee.license(fixture_path(fixture)).key
   end
 

--- a/test/test_licensee_gemspec_matcher.rb
+++ b/test/test_licensee_gemspec_matcher.rb
@@ -3,7 +3,11 @@ require 'helper'
 class TestLicenseeGemspecMatchers < Minitest::Test
   should "detect its own license" do
     root = File.expand_path "../", File.dirname(__FILE__)
-    project = Licensee::GitProject.new(root, detect_packages: true)
+    project = if rugged?
+      Licensee::GitProject.new(root, detect_packages: true)
+    else
+      Licensee::FSProject.new(root, detect_packages: true)
+    end
     matcher = Licensee::Matchers::Gemspec.new(project.package_file)
     assert_equal "mit", matcher.send(:license_property)
     assert_equal "mit", matcher.match.key

--- a/test/test_licensee_license_file.rb
+++ b/test/test_licensee_license_file.rb
@@ -2,9 +2,7 @@ require 'helper'
 
 class TestLicenseeLicenseFile < Minitest::Test
   def setup
-    @repo = Rugged::Repository.new(fixture_path("licenses.git"))
-    blob, _ = Rugged::Blob.to_buffer(@repo, 'bcb552d06d9cf1cd4c048a6d3bf716849c2216cc')
-    @file = Licensee::Project::LicenseFile.new(blob)
+    @file = licenses_file
   end
 
   context "content" do

--- a/test/test_licensee_project.rb
+++ b/test/test_licensee_project.rb
@@ -6,6 +6,9 @@ class TestLicenseeProject < Minitest::Test
   ["git", "filesystem"].each do |project_type|
     describe("#{project_type} repository project") do
       if project_type == "git"
+        # Only test Git-based repos when Rugged is initialized
+        next unless rugged?
+
         def make_project(fixture_name)
           fixture = fixture_path fixture_name
           Licensee::GitProject.new(fixture)
@@ -79,7 +82,11 @@ class TestLicenseeProject < Minitest::Test
 
   describe "packages" do
     should "detect a package file" do
-      project = Licensee::GitProject.new(fixture_path("npm.git"), detect_packages: true)
+      if rugged?
+        project = Licensee::GitProject.new(fixture_path("npm.git"), detect_packages: true)
+      else
+        project = Licensee::FSProject.new(fixture_path("npm"), detect_packages: true)
+      end
       assert_equal "package.json", project.package_file.filename
       assert_equal "mit", project.license.key
     end

--- a/test/test_licensee_project_file.rb
+++ b/test/test_licensee_project_file.rb
@@ -3,9 +3,7 @@ require 'helper'
 class TestLicenseeProjectFile < Minitest::Test
 
   def setup
-    @repo = Rugged::Repository.new(fixture_path("licenses.git"))
-    blob, _ = Rugged::Blob.to_buffer(@repo, 'bcb552d06d9cf1cd4c048a6d3bf716849c2216cc')
-    @file = Licensee::Project::LicenseFile.new(blob)
+    @file = licenses_file
     @gpl = Licensee::License.find "GPL-3.0"
     @mit = Licensee::License.find "MIT"
   end


### PR DESCRIPTION
Per https://github.com/benbalter/licensee/issues/66 this makes the dependency on Rugged optional (falling back to the file system project method).

I'm sympathetic to the fact that needing to compile Rugged adds complexity to local use/development, but am concerned that this approach, although it works, adds significant complexity to the testing process.

On the one hand, we probably should run the test suite as a whole twice, once as a Git repo and once as a file system repo, but the way the tests are currently structured, and the fixtures, that's not the case.

@vmg, @bkeepers any strong opinions one way or the other? I'm fine punting on this for the time being.

/cc @sschuberth, fixes https://github.com/benbalter/licensee/issues/66 
