### PR TITLE
licensee <file> usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Confidence: 98.42%
 Matcher: Licensee::GitMatcher
 ```
 
+Alternately, `licensee <directory>` will treat the argument as the project directory, and `licensee <file>` will attempt to match the individual file specified, both with output that looks like the above.
+
 ## License API
 
 ```ruby

--- a/bin/licensee
+++ b/bin/licensee
@@ -6,9 +6,7 @@ path = ARGV[0] || Dir.pwd
 def print_file(license_file)
   if license_file
     puts "License file: #{license_file.filename}"
-    # if license_file.attribution
     puts "Attribution: #{license_file.attribution}" if license_file.attribution
-    # end
   end
 end
 

--- a/bin/licensee
+++ b/bin/licensee
@@ -3,21 +3,34 @@ require_relative '../lib/licensee'
 
 path = ARGV[0] || Dir.pwd
 
-options = { detect_packages: true, detect_readme: true }
-project = Licensee::GitProject.new(path, options)
-file = project.matched_file
-
-if project.license_file
-  puts "License file: #{project.license_file.filename}"
-  if project.license_file.attribution
-    puts "Attribution: #{project.license_file.attribution}"
+def print_file(license_file)
+  if license_file
+    puts "License file: #{license_file.filename}"
+    # if license_file.attribution
+    puts "Attribution: #{license_file.attribution}" if license_file.attribution
+    # end
   end
 end
 
-if file
-  puts "License: #{file.license ? file.license.meta['title'] : 'no license'}"
-  puts "Confidence: #{file.confidence}%"
-  puts "Method: #{file.matcher.class}"
+def print_evaluation(file)
+  if file
+    puts "License: #{file.license ? file.license.meta['title'] : 'no license'}"
+    puts "Confidence: #{file.confidence}%"
+    puts "Method: #{file.matcher.class}"
+  else
+    puts 'Unknown'
+  end
+end
+
+if File.file?(path)
+  contents = File.open(path).read
+  license_file = Licensee::Project::LicenseFile.new(contents, path)
+  print_file(license_file)
+  print_evaluation(license_file)
 else
-  puts 'Unknown'
+  options = { detect_packages: true, detect_readme: true }
+  project = Licensee::GitProject.new(path, options)
+  file = project.matched_file
+  print_file(project.license_file)
+  print_evaluation(file)
 end

--- a/test/test_licensee_bin.rb
+++ b/test/test_licensee_bin.rb
@@ -15,4 +15,19 @@ class TestLicenseeBin < Minitest::Test
     assert_equal 0, status
     assert stderr.empty?
   end
+
+  should 'work via commandline with file argument' do
+    root = File.expand_path '..', File.dirname(__FILE__)
+    Dir.chdir root
+    stdout, stderr, status = Open3.capture3("#{root}/bin/licensee LICENSE.md")
+
+    msg = "expected #{stdout} to include `License: MIT`"
+    assert stdout.include?('License: MIT'), msg
+
+    msg = "expected #{stdout} to include `Matched file: LICENSE.md`"
+    assert stdout.include?('License file: LICENSE.md'), msg
+
+    assert_equal 0, status
+    assert stderr.empty?
+  end
 end


### PR DESCRIPTION
allow ad hoc cli matching of individual license files not in a
particular project location

I might be the only person in the universe who wants this, in which case I'm happy to create a ruby script for myself that [ab]uses licensee rather than have this be in licensee.