### PR TITLE
Ensure files are read with UTF-8 encoding by default

### DIFF
--- a/bin/licensee
+++ b/bin/licensee
@@ -21,7 +21,7 @@ def print_evaluation(file)
 end
 
 if File.file?(path)
-  contents = File.open(path).read
+  contents = File.read(path, encoding: 'utf-8')
   license_file = Licensee::Project::LicenseFile.new(contents, path)
   print_file(license_file)
   print_evaluation(license_file)

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -140,7 +140,7 @@ module Licensee
     def raw_content
       return if pseudo_license?
       @raw_content ||= if File.exist?(path)
-        File.open(path).read
+        File.read(path, encoding: 'utf-8')
       else
         raise Licensee::InvalidLicense, "'#{key}' is not a valid license key"
       end

--- a/test/functions.rb
+++ b/test/functions.rb
@@ -12,7 +12,7 @@ def fixture_path(fixture)
 end
 
 def license_from_path(path)
-  license = File.open(path).read.match(/\A(---\n.*\n---\n+)?(.*)/m).to_a[2]
+  license = File.read(path, encoding: 'utf-8').match(/\A(---\n.*\n---\n+)?(.*)/m).to_a[2]
   license.sub! '[fullname]', 'Ben Balter'
   license.sub! '[year]', '2014'
   license.sub! '[email]', 'ben@github.invalid'

--- a/test/test_licensee_copyright_matcher.rb
+++ b/test/test_licensee_copyright_matcher.rb
@@ -27,7 +27,8 @@ class TestLicenseeCopyrightMatchers < Minitest::Test
   end
 
   should 'not false positive' do
-    text = File.open(Licensee::License.find('mit').path).read.split('---').last
+    path = Licensee::License.find('mit').path
+    text = File.read(path, encoding: 'utf-8').split('---').last
     file = Licensee::Project::LicenseFile.new(text)
     assert_equal nil, Licensee::Matchers::Copyright.new(file).match
   end

--- a/test/test_licensee_exact_matcher.rb
+++ b/test/test_licensee_exact_matcher.rb
@@ -2,7 +2,8 @@ require 'helper'
 
 class TestLicenseeExactMatchers < Minitest::Test
   def setup
-    text = File.open(Licensee::License.find('mit').path).read.split('---').last
+    path = Licensee::License.find('mit').path
+    text = File.read(path, encoding: 'utf-8').split('---').last
     @mit = Licensee::Project::LicenseFile.new(text)
   end
 


### PR DESCRIPTION
On Windows, simply running

    $ bin/licensee LICENSE.md

resulted in

    content_helper.rb:22: in `gsub!': incompatible encoding regexp match
    (UTF-8 regexp with IBM437 string)

because both the input file and the license files (like "afl-3.0.txt"
which contains Unicode quotes) were read as IBM437-encoded strings. Fix
this by explicitly reading them as UTF-8 strings.