### PR TITLE
Commonly use Licensee.project() both for scanning files and directories

### DIFF
--- a/bin/licensee
+++ b/bin/licensee
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+
 require_relative '../lib/licensee'
 
 path = ARGV[0] || Dir.pwd
@@ -20,15 +21,6 @@ def print_evaluation(file)
   end
 end
 
-if File.file?(path)
-  contents = File.read(path, encoding: 'utf-8')
-  license_file = Licensee::Project::LicenseFile.new(contents, path)
-  print_file(license_file)
-  print_evaluation(license_file)
-else
-  options = { detect_packages: true, detect_readme: true }
-  project = Licensee::GitProject.new(path, options)
-  file = project.matched_file
-  print_file(project.license_file)
-  print_evaluation(file)
-end
+project = Licensee.project(path, detect_packages: true, detect_readme: true)
+print_file(project.license_file)
+print_evaluation(project.matched_file)

--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -41,10 +41,10 @@ module Licensee
       Licensee.project(path).license
     end
 
-    def project(path)
-      Licensee::GitProject.new(path)
+    def project(path, **args)
+      Licensee::GitProject.new(path, args)
     rescue Licensee::GitProject::InvalidRepository
-      Licensee::FSProject.new(path)
+      Licensee::FSProject.new(path, args)
     end
 
     def confidence_threshold


### PR DESCRIPTION
Defer the file check to the begin / rescue block in Licensee.project() as
creating a GitProject would fail for a file.