### PR TITLE
Pseudo licenses should have default meta

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :test do
+  # Active support >= 5 requires Ruby > 2.2
+  gem 'activesupport', "< 5"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gemspec
 
 group :test do
   # Active support >= 5 requires Ruby > 2.2
-  gem 'activesupport', "< 5"
+  gem 'activesupport', '< 5'
 end

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -76,9 +76,10 @@ module Licensee
       @path ||= File.expand_path "#{@key}.txt", Licensee::License.license_dir
     end
 
-    # License metadata from YAML front matter
+    # License metadata from YAML front matter with defaults merged in
     def meta
-      @meta ||= if parts && parts[1]
+      @meta ||= begin
+        return YAML_DEFAULTS unless parts && parts[1]
         meta = if YAML.respond_to? :safe_load
           YAML.safe_load(parts[1])
         else
@@ -90,11 +91,11 @@ module Licensee
 
     # Returns the human-readable license name
     def name
-      meta.nil? ? key.capitalize : meta['title']
+      meta['title'] ? meta['title'] : key.capitalize
     end
 
     def nickname
-      meta['nickname'] if meta
+      meta['nickname']
     end
 
     def name_without_version
@@ -102,14 +103,11 @@ module Licensee
     end
 
     def featured?
-      return YAML_DEFAULTS['featured'] unless meta
       meta['featured']
     end
     alias featured featured?
 
     def hidden?
-      return true if PSEUDO_LICENSES.include?(key)
-      return YAML_DEFAULTS['hidden'] unless meta
       meta['hidden']
     end
 

--- a/test/test_licensee_license.rb
+++ b/test/test_licensee_license.rb
@@ -106,7 +106,11 @@ class TestLicenseeLicense < Minitest::Test
     license = Licensee::License.new('other')
     assert_equal nil, license.content
     assert_equal 'Other', license.name
+    assert license.hidden?
     refute license.featured?
+    Licensee::License::YAML_DEFAULTS.each do |key, value|
+      assert_equal value, license.meta[key]
+    end
   end
 
   should 'know the license hash' do

--- a/test/test_licensee_project.rb
+++ b/test/test_licensee_project.rb
@@ -90,12 +90,14 @@ class TestLicenseeProject < Minitest::Test
 
     should 'detect the BSD 2-clause license without title' do
       verify_license_file fixture_path(
-        'bsd-2-clause-without-title/bsd-2-clause.txt')
+        'bsd-2-clause-without-title/bsd-2-clause.txt'
+      )
     end
 
     should 'detect the BSD 3-Clause license without title' do
       verify_license_file fixture_path(
-        'bsd-3-clause-without-title/bsd-3-clause.txt')
+        'bsd-3-clause-without-title/bsd-3-clause.txt'
+      )
     end
 
     should 'detect the ISC license without title' do


### PR DESCRIPTION
Licenses like `other` should have the default meta, rather than `meta` returning `nil` which will cause errors when calling e.g., `license.meta['spdx-id']`.