### PR TITLE
harmonize scoring based on extension (fixes #109)

### DIFF
--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -14,10 +14,13 @@ module Licensee
 
       def self.name_score(filename)
         return 1.0 if filename =~ /\A(un)?licen[sc]e\z/i
-        return 0.9 if filename =~ /\A(un)?licen[sc]e\.(md|markdown|txt)\z/i
-        return 0.8 if filename =~ /\Acopy(ing|right)(\.[^.]+)?\z/i
-        return 0.7 if filename =~ /\A(un)?licen[sc]e\.[^.]+\z/i
-        return 0.5 if filename =~ /licen[sc]e/i
+        return 0.9 if filename =~ /\Acopy(ing|right)\z/i
+        return 0.8 if filename =~ /\A(un)?licen[sc]e\.(md|markdown|txt)\z/i
+        return 0.7 if filename =~ /\Acopy(ing|right)\.(md|markdown|txt)\z/i
+        return 0.6 if filename =~ /\A(un)?licen[sc]e\.[^.]+\z/i
+        return 0.5 if filename =~ /\Acopy(ing|right)\.[^.]+\z/i
+        return 0.4 if filename =~ /(un)?licen[sc]e/i
+        return 0.3 if filename =~ /copy(ing|right)/i
         0.0
       end
 

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -14,8 +14,8 @@ module Licensee
 
       def self.name_score(filename)
         return 1.0 if filename =~ /\A(un)?licen[sc]e\z/i
-        return 0.9 if filename =~ /\Acopy(ing|right)\z/i
-        return 0.8 if filename =~ /\A(un)?licen[sc]e\.(md|markdown|txt)\z/i
+        return 0.9 if filename =~ /\A(un)?licen[sc]e\.(md|markdown|txt)\z/i
+        return 0.8 if filename =~ /\Acopy(ing|right)\z/i
         return 0.7 if filename =~ /\Acopy(ing|right)\.(md|markdown|txt)\z/i
         return 0.6 if filename =~ /\A(un)?licen[sc]e\.[^.]+\z/i
         return 0.5 if filename =~ /\Acopy(ing|right)\.[^.]+\z/i

--- a/test/licensee/project_files/test_license_file.rb
+++ b/test/licensee/project_files/test_license_file.rb
@@ -40,11 +40,17 @@ class TestLicenseeLicenseFile < Minitest::Test
       'license.txt'        => 0.9,
       'COPYING'            => 0.8,
       'copyRIGHT'          => 0.8,
-      'COPYRIGHT.txt'      => 0.8,
-      'LICENSE.php'        => 0.7,
-      'LICENSE-MIT'        => 0.5,
-      'MIT-LICENSE.txt'    => 0.5,
-      'mit-license-foo.md' => 0.5,
+      'COPYRIGHT.txt'      => 0.7,
+      'copying.txt'        => 0.7,
+      'LICENSE.php'        => 0.6,
+      'LICENCE.docs'       => 0.6,
+      'copying.image'      => 0.5,
+      'COPYRIGHT.go'       => 0.5,
+      'LICENSE-MIT'        => 0.4,
+      'MIT-LICENSE.txt'    => 0.4,
+      'mit-license-foo.md' => 0.4,
+      'COPYING-GPL'        => 0.3,
+      'COPYRIGHT-BSD'      => 0.3,
       'README.txt'         => 0.0
     }.freeze
 


### PR DESCRIPTION
This change implements the following ranking:

1. No extension: LICENSE, COPYING, etc.
3. Filetype extension (syntactic annotation): UNLICENSE.txt, COPYRIGHT.md, etc.
2. Content-related extension (semantic annotation): COPYING.image, LICENCE.go, etc.