### PR TITLE
update documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to Licensee
+
+Interested in contributing to Licensee? We’d love your help. Licensee is an open source project, built one contribution at a time by users like you.
+
+## Adding a license
+
+Licensee doesn't curate any license information directly. Instead, we rely on the licenses and metadata provided by choosealicense.com and its much larger community (which can properly vet licenses and make determinations as to their properties).
+
+Interested in adding support for Licensee to detect an additional license? Please [follow these instructions](https://github.com/github/choosealicense.com/blob/gh-pages/CONTRIBUTING.md#adding-a-license) to submit a pull request to get the license added upstream, and it will be automatically vendored (and detected) here.
+
+## Updating the licenses
+
+License data is pulled from `choosealicense.com`. To update the license data, simple run `script/vendor-licenses`.
+
+## Bootstrapping a local development environment
+
+`script/bootstrap`
+
+## Running tests
+
+`script/cibuild`
+
+## Roadmap
+
+See [proposed enhancements](https://github.com/benbalter/licensee/labels/enhancement).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-2016 Ben Balter
+Copyright (c) 2014–2016 Ben Balter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,23 +1,37 @@
 # Licensee
-_A Ruby Gem to detect under what license a project is distributed._
+
+*A Ruby Gem to detect under what license a project is distributed.*
 
 [![Build Status](https://travis-ci.org/benbalter/licensee.svg?branch=master)](https://travis-ci.org/benbalter/licensee) [![Gem Version](https://badge.fury.io/rb/licensee.svg)](http://badge.fury.io/rb/licensee)
 
 ## The problem
-- You've got an open source project. How do you know what you can and can't do with the software?
-- You've got a bunch of open source projects, how do you know what their licenses are?
-- You've got a project with a license file, but which license is it? Has it been modified?
+
+* You've got an open source project. How do you know what you can and can't do with the software?
+* You've got a bunch of open source projects, how do you know what their licenses are?
+* You've got a project with a license file, but which license is it? Has it been modified?
 
 ## The solution
-Licensee automates the process of reading `LICENSE` files and compares their contents to known licenses using a several strategies (which we call "Matchers"). It attempts to determine a project's license in the following order:
-- If the license file has an explicit copyright notice, and nothing more (e.g., `Copyright (c) 2015 Ben Balter`), we'll assume the author intends to retain all rights, and thus the project isn't licensed.
-- If the license is an exact match to a known license. If we strip away whitespace and copyright notice, we might get lucky, and direct string comparison in Ruby is cheap.
-- If we still can't match the license, we use a fancy math thing called the [Sørensen–Dice coefficient](https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient), which is really good at calculating the similarity between two strings. By calculating the percent changed from the known license to the license file, you can tell, e.g., that a given license is 90% similar to the MIT license, that 10% likely representing the copyright line being properly adapted to the project.
 
-_Special thanks to [@vmg](https://github.com/vmg) for his Git and algorithmic prowess._
+Licensee automates the process of reading `LICENSE` files and compares their contents to known licenses using a several strategies (which we call "Matchers"). It attempts to determine a project's license in the following order:
+
+* If the license file has an explicit copyright notice, and nothing more (e.g., `Copyright (c) 2015 Ben Balter`), we'll assume the author intends to retain all rights, and thus the project isn't licensed.
+* If the license is an exact match to a known license. If we strip away whitespace and copyright notice, we might get lucky, and direct string comparison in Ruby is cheap.
+* If we still can't match the license, we use a fancy math thing called the [Sørensen–Dice coefficient](https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient), which is really good at calculating the similarity between two strings. By calculating the percent changed from the known license to the license file, you can tell, e.g., that a given license is 95% similar to the MIT license, that 5% likely representing legally insignificant changes to the license text.
+
+*Special thanks to [@vmg](https://github.com/vmg) for his Git and algorithmic prowess.*
 
 ## Installation
+
 `gem install licensee` or add `gem 'licensee'` to your project's `Gemfile`.
+
+## Documentation
+
+See [the docs folder](/docs) for more information. You may be interested in:
+
+* [Contributing to Licensee](CONTRIBUTING.md) (and development instructions)
+* [Customizing Licensee's behavior](docs/customizing.md)
+* [Instructions for using Licensee](docs/usage.md)
+* More information about [what Licensee looks at](docs/what-we-look-at.md) (or doesn't, and why)
 
 ## Semantic Versioning
 
@@ -28,98 +42,3 @@ spec.add_dependency 'licensee', '~> 1.0'
 This means your project is compatible with licensee 1.0 up until 2.0. You can also set a higher minimum version:
 
 spec.add_dependency 'licensee', '~> 1.1'
-
-## Command line usage
-1. `cd` into a project directory
-2. execute the `licensee` command
-
-You'll get an output that looks like:
-
-```
-License: MIT
-Confidence: 98.42%
-Matcher: Licensee::GitMatcher
-```
-
-Alternately, `licensee <directory>` will treat the argument as the project directory, and `licensee <file>` will attempt to match the individual file specified, both with output that looks like the above.
-
-## License API
-
-```ruby
-license = Licensee.license "/path/to/a/project"
-=> #<Licensee::License name="MIT" match=0.9842154131847726>
-
-license.key
-=> "mit"
-
-license.name
-=> "MIT License"
-
-license.meta["source"]
-=> "http://opensource.org/licenses/MIT"
-
-license.meta["description"]
-=> "A permissive license that is short and to the point. It lets people do anything with your code with proper attribution and without warranty."
-
-license.meta["permissions"]
-=> ["commercial-use","modifications","distribution","private-use"]
-```
-
-## More API
-You can gather more information by working with the project object, and the top level Licensee class. 
-
-```ruby
- Licensee::VERSION                                 # The Licensee version
- Licensee.licenses                                 # All the licenses Licensee knows about
-
- project=Licensee.project "/path/to/a/project"     # Get a Project (Git checkout or just local Filesystem) (post 6.0.0)
-
- project.license                                   # The matched license
- project.matched_file                              # Object for the particular file containing the apparent license
- project.matched_file.filename                     #   Its filename
- project.matched_file.confidence                   #   The confidence level in the license matching
- project.matched_file.content                      #   The content of your license file
- project.license.content                           # The Open Source License text it matched against
-```
-
-## What it looks at
-- `LICENSE`, `LICENSE.txt`, `COPYING`, etc. files in the root of the project, comparing the body to known licenses
-- Crowdsourced license content and metadata from [`choosealicense.com`](http://choosealicense.com)
-
-## What it doesn't look at
-- Dependency licensing
-- References to licenses in `README`, `README.md`, etc.
-- Every single possible license (just the most popular ones)
-- Compliance (e.g., whitelisting certain licenses)
-
-If you're looking for dependency license checking and compliance, take a look at [LicenseFinder](https://github.com/pivotal/LicenseFinder).
-
-## Huh? Why don't you look at X?
-Because reasons.
-
-### Why not just look at the "license" field of [insert package manager here]?
-Because it's not legally binding. A license is a legal contract. You give up certain rights (e.g., the right to sue the author) in exchange for the right to use the software.
-
-Most popular licenses today _require_ that the license itself be distributed along side the software. Simply putting the letters "MIT" or "GPL" in a configuration file doesn't really meet that requirement.
-
-Not to mention, it doesn't tell you much about your rights as a user. Is it GPLv2? GPLv2 or later? Those files are designed to be read by computers (who can't enter into contracts), not humans (who can). It's great metadata, but that's about it.
-
-### What about looking to see if the author said something in the readme?
-You could make an argument that, when linked or sufficiently identified, the terms of the license are incorporated by reference, or at least that the author's intent is there. There's a handful of reasons why this isn't ideal. For one, if you're using the MIT or BSD (ISC) license, along with a few others, there's templematic language, like the copyright notice, which would go unfilled.
-
-### What about checking every single file for a copyright header?
-Because that's silly in the context of how software is developed today. You wouldn't put a copyright notice on each page of a book. Besides, it's a lot of work, as there's no standardized, cross-platform way to describe a project's license within a comment.
-
-Checking the actual text into version control is definitive, so that's what this project looks at.
-
-## Bootstrapping a local development environment
-`script/bootstrap`
-
-## Running tests
-`script/cibuild`
-
-## Updating the licenses
-License data is pulled from `choosealicense.com`. To update the license data, simple run `script/vendor-licenses`.
-
-## Roadmap
-See [proposed enhancements](https://github.com/benbalter/licensee/labels/enhancement).

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -1,0 +1,33 @@
+# Customizing Licensee's behavior
+
+## Adjusting the confidence threshold
+
+If you'd like, you can make Licensee less stringent in its comparison, but risk getting false positives as a result. The confidence threshold is an integer between 1 and 100, with the default being 95, meaning that License is at least 95% confident that the file represents the matched license.
+
+```ruby
+LICENSEE.confidence_threshold
+=> 95
+
+LICENSEE.confidence_threshold = 90
+=> 90
+```
+
+## Matching package manager metadata
+
+Licensee supports the ability to take into account Ruby or Node package manager metadata, disabled by default. [There are reasons you may not want to use this metadata](what-we-look-at). You can explicitly instruct licensee to take this information into account as follows:
+
+```ruby
+project = Licensee::Project.new("path/to/project", detect_packages: true)
+project.license
+=> #<Licensee::Licensee key="mit">
+```
+
+## Matching project README license references
+
+Licensee supports the ability to take into account human readable references to licenses within the project's README, disabled by default. [There are reasons you may not want to use this](what-we-look-at). You can explicitly instruct licensee to take this information into account as follows:
+
+```ruby
+project = Licensee::Project.new("path/to/project", detect_readme: true)
+project.license
+=> #<Licensee::Licensee key="mit">
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,56 @@
+# Using Licensee
+
+## Command line usage
+
+1. `cd` into a project directory
+2. Execute the `licensee` command
+
+You'll get an output that looks like:
+
+```
+License: MIT
+Confidence: 98.42%
+Matcher: Licensee::GitMatcher
+```
+
+Alternately, `licensee <directory>` will treat the argument as the project directory, and `licensee <file>` will attempt to match the individual file specified, both with output that looks like the above.
+
+## License Ruby API
+
+```ruby
+license = Licensee.license "/path/to/a/project"
+=> #<Licensee::License name="MIT" match=0.9842154131847726>
+
+license.key
+=> "mit"
+
+license.name
+=> "MIT License"
+
+license.meta["source"]
+=> "http://opensource.org/licenses/MIT"
+
+license.meta["description"]
+=> "A permissive license that is short and to the point. It lets people do anything with your code with proper attribution and without warranty."
+
+license.meta["permissions"]
+=> ["commercial-use","modifications","distribution","private-use"]
+```
+
+## Advanced API usage
+
+You can gather more information by working with the project object, and the top level Licensee class.
+
+```ruby
+ Licensee::VERSION                                 # The Licensee version
+ Licensee.licenses                                 # All the licenses Licensee knows about
+
+ project = Licensee.project "/path/to/a/project"   # Get a Project (Git checkout or just local Filesystem) (post 6.0.0)
+
+ project.license                                   # The matched license
+ project.matched_file                              # Object for the particular file containing the apparent license
+ project.matched_file.filename                     #   Its filename
+ project.matched_file.confidence                   #   The confidence level in the license matching
+ project.matched_file.content                      #   The content of your license file
+ project.license.content                           # The Open Source License text it matched against
+```

--- a/docs/what-we-look-at.md
+++ b/docs/what-we-look-at.md
@@ -1,0 +1,48 @@
+# What we look at
+
+Licensee works by taking a detected license file, and comparing the contents to a short list of known licenses.
+
+## Detecting the license file
+
+Licensee uses [a series of regular expressions](https://github.com/benbalter/licensee/blob/master/lib/licensee/project_files/license_file.rb#L15-L25) to score files in the project's root as potential license files. Here's a few examples of files that would be detected:
+
+* `LICENSE`
+* `LICENCE`
+* `license.md`
+* `COPYING.txt`
+* `LICENSE-MIT`
+* `COPYRIGHT`
+* `UNLICENSE`
+
+## Known licenses
+
+Licensee relies on the crowdsourced license content and metadata from [`choosealicense.com`](http://choosealicense.com).
+
+## What it doesn't look at
+
+* The licensing of a project's dependencies
+* References to licenses in `README`, `README.md`, etc.
+* Every single possible license (just the most popular ones)
+* Compliance - If you're looking for this, take a look at [LicenseFinder](https://github.com/pivotal/LicenseFinder).
+
+## Huh? Why don't you look at X?
+
+Because reasons.
+
+### Why not just look at the "license" field of [insert package manager here]?
+
+Because it's not legally binding. A license is a legal contract. You give up certain rights (e.g., the right to sue the author) in exchange for the right to use the software.
+
+Most popular licenses today *require* that the license itself be distributed along side the software. Simply putting the letters "MIT" or "GPL" in a configuration file doesn't really meet that requirement.
+
+Not to mention, it doesn't tell you much about your rights as a user. Is it GPLv2? GPLv2 or later? Those files are designed to be read by computers (who can't enter into contracts), not humans (who can). It's great metadata, but that's about it.
+
+### What about looking to see if the author said something in the readme?
+
+You could make an argument that, when linked or sufficiently identified, the terms of the license are incorporated by reference, or at least that the author's intent is there. There's a handful of reasons why this isn't ideal. For one, if you're using the MIT or BSD (ISC) license, along with a few others, there's templematic language, like the copyright notice, which would go unfilled.
+
+### What about checking every single file for a copyright header?
+
+Because that's silly in the context of how software is developed today. You wouldn't put a copyright notice on each page of a book. Besides, it's a lot of work, as there's no standardized, cross-platform way to describe a project's license within a comment.
+
+Checking the actual text into version control is definitive, so that's what this project looks at.


### PR DESCRIPTION
This PR overhauls most of the project's documentation to make things explicit. This includes:

* What we look at
* How to add a license
* How to enable README or package manager detection
* How to contribute

Most of the changes here is just moving/organizing existing documentation, with a bit of additional clarity. Docs now live in the `/docs` folder.

I'm going to go ahead and merge this PR, to get the documentation updated immediately (since it's linked from the GitHub blog post), but very open to feedback on this PR, which I'd be glad to address in a subsequent iteration.

Fixes https://github.com/benbalter/licensee/issues/123.
Fixes https://github.com/benbalter/licensee/issues/122.