### PR TITLE
Break license regex into constants

### DIFF
--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -5,10 +5,10 @@ module Licensee
 
       # List of extensions to give preference to
       PREFERRED_EXT = %w(md markdown txt).freeze
-      PREFERRED_EXT_REGEX = "\.#{Regexp.union(PREFERRED_EXT)}".freeze
+      PREFERRED_EXT_REGEX = /\.#{Regexp.union(PREFERRED_EXT)}\z/
 
       # Regex to match any extension
-      ANY_EXT_REGEX = /\.[^.]+/
+      ANY_EXT_REGEX = %r{\.[^./]+\z}
 
       # Regex to match, LICENSE, LICENCE, unlicense, etc.
       LICENSE_REGEX = /(un)?licen[sc]e/i

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -4,11 +4,11 @@ module Licensee
       include Licensee::ContentHelper
 
       # List of extensions to give preference to
-      EXTENSIONS = %w(md markdown txt).freeze
-      EXTENSIONS_REGEX = Regexp.union(EXTENSIONS)
+      PREFERRED_EXT = %w(md markdown txt).freeze
+      PREFERRED_EXT_REGEX = "\.#{Regexp.union(PREFERRED_EXT)}".freeze
 
       # Regex to match any extension
-      ANY_EXTENSION_REGEX = /[^.]+/
+      ANY_EXT_REGEX = /\.[^.]+/
 
       # Regex to match, LICENSE, LICENCE, unlicense, etc.
       LICENSE_REGEX = /(un)?licen[sc]e/i
@@ -18,15 +18,15 @@ module Licensee
 
       # Hash of Regex => score with which to score potential license files
       FILENAME_REGEXES = {
-        /\A#{LICENSE_REGEX}\z/                         => 1.0, # LICENSE
-        /\A#{LICENSE_REGEX}\.#{EXTENSIONS_REGEX}\z/    => 0.9, # LICENSE.md
-        /\A#{COPYING_REGEX}\z/                         => 0.8, # COPYING
-        /\A#{COPYING_REGEX}\.#{EXTENSIONS_REGEX}\z/    => 0.7, # COPYING.md
-        /\A#{LICENSE_REGEX}\.#{ANY_EXTENSION_REGEX}\z/ => 0.6, # LICENSE.textile
-        /\A#{COPYING_REGEX}\.#{ANY_EXTENSION_REGEX}\z/ => 0.5, # COPYING.textile
-        /#{LICENSE_REGEX}/                             => 0.4, # LICENSE-MIT
-        /#{COPYING_REGEX}/                             => 0.3, # COPYING-MIT
-        //                                             => 0.0  # Catch all
+        /\A#{LICENSE_REGEX}\z/                       => 1.0, # LICENSE
+        /\A#{LICENSE_REGEX}#{PREFERRED_EXT_REGEX}\z/ => 0.9, # LICENSE.md
+        /\A#{COPYING_REGEX}\z/                       => 0.8, # COPYING
+        /\A#{COPYING_REGEX}#{PREFERRED_EXT_REGEX}\z/ => 0.7, # COPYING.md
+        /\A#{LICENSE_REGEX}#{ANY_EXT_REGEX}\z/       => 0.6, # LICENSE.textile
+        /\A#{COPYING_REGEX}#{ANY_EXT_REGEX}\z/       => 0.5, # COPYING.textile
+        /#{LICENSE_REGEX}/                           => 0.4, # LICENSE-MIT
+        /#{COPYING_REGEX}/                           => 0.3, # COPYING-MIT
+        //                                           => 0.0  # Catch all
       }.freeze
 
       def possible_matchers

--- a/test/licensee/project_files/test_license_file.rb
+++ b/test/licensee/project_files/test_license_file.rb
@@ -5,7 +5,8 @@ class TestLicenseeLicenseFile < Minitest::Test
     @repo = Rugged::Repository.new(fixture_path('licenses.git'))
     ref   = 'bcb552d06d9cf1cd4c048a6d3bf716849c2216cc'
     blob, = Rugged::Blob.to_buffer(@repo, ref)
-    @file = Licensee::Project::LicenseFile.new(blob)
+    @class = Licensee::Project::LicenseFile
+    @file = @class.new(blob)
   end
 
   context 'content' do
@@ -15,7 +16,7 @@ class TestLicenseeLicenseFile < Minitest::Test
 
     should 'not choke on non-UTF-8 licenses' do
       text = "\x91License\x93".force_encoding('windows-1251')
-      file = Licensee::Project::LicenseFile.new(text)
+      file = @class.new(text)
       assert_equal nil, file.attribution
     end
 
@@ -56,7 +57,7 @@ class TestLicenseeLicenseFile < Minitest::Test
 
     EXPECTATIONS.each do |filename, expected|
       should "score a license named `#{filename}` as `#{expected}`" do
-        score = Licensee::Project::LicenseFile.name_score(filename)
+        score = @class.name_score(filename)
         assert_equal expected, score
       end
     end
@@ -71,8 +72,50 @@ class TestLicenseeLicenseFile < Minitest::Test
       'FOO.md'         => 0
     }.each do |filename, expected|
       should "score a license named `#{filename}` as `#{expected}`" do
-        score = Licensee::Project::LicenseFile.lesser_gpl_score(filename)
+        score = @class.lesser_gpl_score(filename)
         assert_equal expected, score
+      end
+    end
+  end
+
+  context 'preferred license regex' do
+    %w(md markdown txt).each do |ext|
+      should "match .#{ext}" do
+        assert_match @class::PREFERRED_EXT_REGEX, ".#{ext}"
+      end
+    end
+
+    should 'not match .md2' do
+      refute_match @class::PREFERRED_EXT_REGEX, '.md2'
+    end
+
+    should 'not match .md/foo' do
+      refute_match @class::PREFERRED_EXT_REGEX, '.md/foo'
+    end
+  end
+
+  context 'any extension regex' do
+    should 'match .foo' do
+      assert_match @class::ANY_EXT_REGEX, '.foo'
+    end
+
+    should 'not match .md/foo' do
+      refute_match @class::ANY_EXT_REGEX, '.md/foo'
+    end
+  end
+
+  context 'license regex' do
+    %w(LICENSE licence unlicense LICENSE-MIT MIT-LICENSE).each do |license|
+      should "match #{license}" do
+        assert_match @class::LICENSE_REGEX, license
+      end
+    end
+  end
+
+  context 'copying regex' do
+    %w(COPYING copyright).each do |copying|
+      should "match #{copying}" do
+        assert_match @class::COPYING_REGEX, copying
       end
     end
   end


### PR DESCRIPTION
This PR is a refactor intended to DRY up the license file regex a bit.

Rubocop is complaining that `LicenseFIle#name_score` is too complex, and I tend to agree.

Rather than using a series of if statements, this PR moves the logic to iterate through a hash of regexes.

As I did that, I also realized there was a lot of copy-🍝  going on, and DRY'd things up a bit by moving the repeated regex clauses to their own constants.

The end result should be functionally the same, but in my opinion, a cleaner implementation, and should be easier to maintain going forward.