### PR TITLE
Add support for the CRAN package manager for R packages.

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -14,7 +14,7 @@ LICENSEE.confidence_threshold = 90
 
 ## Matching package manager metadata
 
-Licensee supports the ability to take into account Ruby or Node package manager metadata, disabled by default. [There are reasons you may not want to use this metadata](what-we-look-at.md). You can explicitly instruct licensee to take this information into account as follows:
+Licensee supports the ability to take into account Ruby, Node and CRAN package manager metadata, disabled by default. [There are reasons you may not want to use this metadata](what-we-look-at.md). You can explicitly instruct licensee to take this information into account as follows:
 
 ```ruby
 project = Licensee.project("path/to/project", detect_packages: true)

--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -20,6 +20,7 @@ require_relative 'licensee/matchers/dice_matcher'
 require_relative 'licensee/matchers/package_matcher'
 require_relative 'licensee/matchers/gemspec_matcher'
 require_relative 'licensee/matchers/npm_bower_matcher'
+require_relative 'licensee/matchers/cran_matcher'
 
 module Licensee
   # Over which percent is a match considered a match by default

--- a/lib/licensee/matchers/cran_matcher.rb
+++ b/lib/licensee/matchers/cran_matcher.rb
@@ -1,0 +1,18 @@
+module Licensee
+  module Matchers
+    class Cran < Package
+      # While we could parse the package.json or bower.json file, prefer
+      # a lenient regex for speed and security. Moar parsing moar problems.
+      LICENSE_REGEX = /
+        ^license:\s*([a-z\-0-9\.]+)
+      /ix
+
+      private
+
+      def license_property
+        match = @file.content.match LICENSE_REGEX
+        match[1].downcase if match && match[1]
+      end
+    end
+  end
+end

--- a/lib/licensee/project_files/package_info.rb
+++ b/lib/licensee/project_files/package_info.rb
@@ -2,6 +2,9 @@ module Licensee
   class Project
     class PackageInfo < Licensee::Project::File
       def possible_matchers
+        if filename == 'DESCRIPTION'
+          return [Matchers::Cran]
+        end
         case ::File.extname(filename)
         when '.gemspec'
           [Matchers::Gemspec]
@@ -14,6 +17,7 @@ module Licensee
 
       def self.name_score(filename)
         return 1.0  if ::File.extname(filename) == '.gemspec'
+        return 1.0  if filename == 'DESCRIPTION'
         return 1.0  if filename == 'package.json'
         return 0.75 if filename == 'bower.json'
         0.0

--- a/lib/licensee/project_files/package_info.rb
+++ b/lib/licensee/project_files/package_info.rb
@@ -2,7 +2,9 @@ module Licensee
   class Project
     class PackageInfo < Licensee::Project::File
       def possible_matchers
-        return [Matchers::Cran] if filename == 'DESCRIPTION'
+        if filename == 'DESCRIPTION' && ::File.start_with?('Package:')
+          return [Matchers::Cran]
+        end
         case ::File.extname(filename)
         when '.gemspec'
           [Matchers::Gemspec]

--- a/lib/licensee/project_files/package_info.rb
+++ b/lib/licensee/project_files/package_info.rb
@@ -2,9 +2,7 @@ module Licensee
   class Project
     class PackageInfo < Licensee::Project::File
       def possible_matchers
-        if filename == 'DESCRIPTION'
-          return [Matchers::Cran]
-        end
+        return [Matchers::Cran] if filename == 'DESCRIPTION'
         case ::File.extname(filename)
         when '.gemspec'
           [Matchers::Gemspec]

--- a/test/fixtures/cran/DESCRIPTION
+++ b/test/fixtures/cran/DESCRIPTION
@@ -1,0 +1,9 @@
+Package: test
+Title: TestPackage
+Version: 0.0.1
+Authors@R: person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre"))
+Description: Test Package
+Depends: R (>= 3.3.0)
+License: MIT + file LICENSE
+Encoding: UTF-8
+LazyData: true

--- a/test/licensee/matchers/test_cran_matcher.rb
+++ b/test/licensee/matchers/test_cran_matcher.rb
@@ -1,0 +1,11 @@
+require 'helper'
+
+class TestLicenseeCranMatchers < Minitest::Test
+  should 'detect CRAN DESCRPITION files' do
+    pkg = File.read fixture_path('cran/DESCRIPTION')
+    pkgfile = Licensee::Project::PackageInfo.new(pkg)
+    matcher = Licensee::Matchers::Cran.new(pkgfile)
+    assert_equal 'mit', matcher.send(:license_property)
+    assert_equal 'mit', matcher.match.key
+  end
+end


### PR DESCRIPTION
This PR adds support for detecting license information for R packages (the [CRAN](cran.r-project.org) package repository).

Cran policy, and R package policy in general (see [Licensing](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Licensing) in the R extensions manual) is that the license contents for standard licenses should _not_ be included in the package. 

In addition for templated licenses (such as MIT) CRAN requires authors to use a LICENSE file with _only_ the follwing (see https://www.r-project.org/Licenses/MIT for the exact instructions)
```
YEAR: 1234
COPYRIGHT HOLDER: XYZ
```

These requirements mean that most R packages are found to be unlicensed by licensee (and consequently GitHub).

This PR adds support for parsing the DESCRIPTION file included in every R package to find the `License:` field. This gets us part of the way to solving the problem.

However because R mandates a restricted LICENSE file for templated licenses and licensee does not use the project matchers if it finds a LICENSE file this PR as written is not sufficient to fix the problem. Licensee would need to fall back to trying the project matchers if no license is found with the normal matching. However as this is a change in the current behavior I did not want to add it to this PR without discussion.