### PR TITLE
Expose license hash via CLI

### DIFF
--- a/bin/licensee
+++ b/bin/licensee
@@ -14,6 +14,7 @@ matched_file = project.matched_file
 
 if license_file
   puts "License file: #{license_file.filename}"
+  puts "License hash: #{license_file.hash}"
   puts "Attribution: #{license_file.attribution}" if license_file.attribution
 end
 


### PR DESCRIPTION
Example output:

```
License file: LICENSE.md
License Hash: 750260c322080bab4c19fd55eb78bc73e1ae8f11
Attribution: Copyright (c) 20142016 Ben Balter
License: MIT License
Confidence: 100.00%
Method: Licensee::Matchers::Exact
```