### PR TITLE
Add .mdown README extension

### DIFF
--- a/lib/licensee/project_files/readme.rb
+++ b/lib/licensee/project_files/readme.rb
@@ -2,8 +2,8 @@ module Licensee
   class Project
     class Readme < LicenseFile
       SCORES = {
-        /\AREADME\z/i                    => 1.0,
-        /\AREADME\.(md|markdown|txt)\z/i => 0.9
+        /\AREADME\z/i                          => 1.0,
+        /\AREADME\.(md|markdown|mdown|txt)\z/i => 0.9
       }.freeze
 
       CONTENT_REGEX = /^#+ Licen[sc]e$(.*?)(?=#+|\z)/im


### PR DESCRIPTION
Many README ([~72,000 on github.com](https://github.com/search?utf8=%E2%9C%93&q=filename%3AREADME.mdown&type=Code&ref=searchresults)) have a `.mdown` extension.
This pull request thus adds this extension to the list of README file extensions recognized.

(We actually have many TextMate grammars at Linguist that use this extension for their README. Thus, I think recognizing it in Licensee would significantly increase the number of license we can automatically detect.)