### PR TITLE
Recognize underlined license headers in READMEs

### DIFF
--- a/lib/licensee/project_files/readme.rb
+++ b/lib/licensee/project_files/readme.rb
@@ -6,7 +6,17 @@ module Licensee
         /\AREADME\.(md|markdown|mdown|txt)\z/i => 0.9
       }.freeze
 
-      CONTENT_REGEX = /^#+ Licen[sc]e$(.*?)(?=#+|\z)/im
+      CONTENT_REGEX = /^
+          (?:\#+\sLicen[sc]e     # Start of hashes-based license header
+             |
+             Licen[sc]e\n[-=]+)$ # Start of underlined license header
+          (.*?)                  # License content
+          (?=^(?:\#+             # Next hashes-based header
+                 |
+                 [^\n]+\n[-=]+)  # Next of underlined header
+             |
+             \z)                 # End of file
+        /mix
 
       def self.name_score(filename)
         SCORES.each do |pattern, score|

--- a/spec/licensee/project_files/readme_spec.rb
+++ b/spec/licensee/project_files/readme_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe Licensee::Project::Readme do
       end
     end
 
+    context 'after an underlined header' do
+      let(:content) { "License\n-------\n\nhello world" }
+
+      it 'returns the license' do
+        expect(license).to eql('hello world')
+      end
+    end
+
     context 'With a strangely cased heading' do
       let(:content) { "## LICENSE\n\nhello world" }
 
@@ -68,6 +76,22 @@ RSpec.describe Licensee::Project::Readme do
 
     context 'with trailing content' do
       let(:content) { "## License\n\nhello world\n\n# Contributing" }
+
+      it 'returns the license' do
+        expect(license).to eql('hello world')
+      end
+    end
+
+    context 'with trailing content that has an underlined header' do
+      let(:content) { "# License\n\nhello world\n\nContributing\n====" }
+
+      it 'returns the license' do
+        expect(license).to eql('hello world')
+      end
+    end
+
+    context 'with trailing content that has a hashes-based header' do
+      let(:content) { "# License\n\nhello world\n\n# Contributing" }
 
       it 'returns the license' do
         expect(license).to eql('hello world')


### PR DESCRIPTION
This pull request adds support for underlined headers in READMEs:
```markdown
License
-------

License body
```
It seems that underlined headers are less common than hashes-based headers, but at the scale of github.com, I guess there are still enough to mandate support. It actually improves detection in a few cases for Linguist.

The regular expression gets fairly more complicated so I broke it down into several commented parts with free-spacing.