### PR TITLE
Expose license rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ vendor/eventie
 vendor/imagesloaded
 vendor/ev-emitter
 vendor/choosealicense.com/_sass
-vendor/choosealicense.com/_data
 vendor/choosealicense.com/_includes
 vendor/choosealicense.com/_layouts
 vendor/choosealicense.com/assets

--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -1,6 +1,7 @@
 require_relative 'licensee/version'
 require_relative 'licensee/content_helper'
 require_relative 'licensee/license'
+require_relative 'licensee/rule'
 
 # Projects
 require_relative 'licensee/project'

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -135,6 +135,19 @@ module Licensee
       PSEUDO_LICENSES.include?(key)
     end
 
+    # Returns a hash in the form of rule_group => rules describing
+    # what you legally can and can't do with the given license
+    def rules
+      return @rules if defined? @rules
+      @rules = {}
+
+      Rule.groups.each do |group|
+        @rules[group] = meta[group].map { |tag| Rule.find_by_tag(tag) }
+      end
+
+      @rules
+    end
+
     def inspect
       "#<Licensee::License key=#{key}>"
     end

--- a/lib/licensee/rule.rb
+++ b/lib/licensee/rule.rb
@@ -1,0 +1,48 @@
+module Licensee
+  class Rule
+    attr_reader :tag, :label, :description, :group
+
+    def initialize(tag: nil, label: nil, description: nil, group: nil)
+      @tag = tag
+      @label = label
+      @description = description
+      @group = group
+    end
+
+    def inspect
+      "#<Licensee::Rule @tag=\"#{tag}\">"
+    end
+
+    class << self
+      def all
+        @all ||= raw_rules.map do |group, rules|
+          rules.map do |rule|
+            Rule.new(
+              tag: rule["tag"],
+              label: rule["label"],
+              description: rule["description"],
+              group: group
+              )
+          end
+        end.flatten
+      end
+
+      def find_by_tag(tag)
+        Rule.all.find { |r| r.tag == tag }
+      end
+
+      def file_path
+        dir = File.dirname(__FILE__)
+        File.expand_path '../../vendor/choosealicense.com/_data/rules.yml', dir
+      end
+
+      def raw_rules
+        YAML.load File.read(Rule.file_path)
+      end
+
+      def groups
+        Rule.raw_rules.keys
+      end
+    end
+  end
+end

--- a/lib/licensee/rule.rb
+++ b/lib/licensee/rule.rb
@@ -18,11 +18,11 @@ module Licensee
         @all ||= raw_rules.map do |group, rules|
           rules.map do |rule|
             Rule.new(
-              tag: rule["tag"],
-              label: rule["label"],
-              description: rule["description"],
-              group: group
-              )
+              tag:         rule['tag'],
+              label:       rule['label'],
+              description: rule['description'],
+              group:       group
+            )
           end
         end.flatten
       end

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -222,9 +222,9 @@ RSpec.describe Licensee::License do
     end.to raise_error(Licensee::InvalidLicense)
   end
 
-  it "returns the rules" do
-    expect(mit.rules).to have_key("permissions")
-    expect(mit.rules["permissions"].first).to be_a(Licensee::Rule)
+  it 'returns the rules' do
+    expect(mit.rules).to have_key('permissions')
+    expect(mit.rules['permissions'].first).to be_a(Licensee::Rule)
     expect(mit.rules.flatten.count).to eql(6)
   end
 end

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -221,4 +221,10 @@ RSpec.describe Licensee::License do
       described_class.new('foo').name
     end.to raise_error(Licensee::InvalidLicense)
   end
+
+  it "returns the rules" do
+    expect(mit.rules).to have_key("permissions")
+    expect(mit.rules["permissions"].first).to be_a(Licensee::Rule)
+    expect(mit.rules.flatten.count).to eql(6)
+  end
 end

--- a/spec/licensee/rule.rb
+++ b/spec/licensee/rule.rb
@@ -1,46 +1,45 @@
 RSpec.describe Licensee::Rule do
-
   let(:groups) { %w(permissions conditions limitations) }
 
-  it "stores the properties" do
+  it 'stores the properties' do
     rule = described_class.new(
-      tag: "tag",
-      label: "label",
-      description: "description",
-      group: "group"
+      tag:         'tag',
+      label:       'label',
+      description: 'description',
+      group:       'group'
     )
 
-    expect(rule.tag).to eql("tag")
-    expect(rule.label).to eql("label")
-    expect(rule.description).to eql("description")
-    expect(rule.group).to eql("group")
+    expect(rule.tag).to eql('tag')
+    expect(rule.label).to eql('label')
+    expect(rule.description).to eql('description')
+    expect(rule.group).to eql('group')
   end
 
-  it "loads the groups" do
+  it 'loads the groups' do
     expect(described_class.groups).to eql(groups)
   end
 
-  it "loads the raw rules" do
+  it 'loads the raw rules' do
     groups.each do |key|
       expect(described_class.raw_rules).to have_key(key)
     end
   end
 
-  it "determines the file path" do
+  it 'determines the file path' do
     path = described_class.file_path
-    expect(File.exists?(path)).to eql(true)
+    expect(File.exist?(path)).to eql(true)
   end
 
-  it "loads a rule by tag" do
-    rule = described_class.find_by_tag("commercial-use")
+  it 'loads a rule by tag' do
+    rule = described_class.find_by_tag('commercial-use')
     expect(rule).to be_a(described_class)
-    expect(rule.tag).to eql("commercial-use")
+    expect(rule.tag).to eql('commercial-use')
   end
 
-  it "loads all rules" do
+  it 'loads all rules' do
     expect(described_class.all.count).to eql(13)
     rule = described_class.all.first
     expect(rule).to be_a(described_class)
-    expect(rule.tag).to eql("commercial-use")
+    expect(rule.tag).to eql('commercial-use')
   end
 end

--- a/spec/licensee/rule.rb
+++ b/spec/licensee/rule.rb
@@ -1,0 +1,46 @@
+RSpec.describe Licensee::Rule do
+
+  let(:groups) { %w(permissions conditions limitations) }
+
+  it "stores the properties" do
+    rule = described_class.new(
+      tag: "tag",
+      label: "label",
+      description: "description",
+      group: "group"
+    )
+
+    expect(rule.tag).to eql("tag")
+    expect(rule.label).to eql("label")
+    expect(rule.description).to eql("description")
+    expect(rule.group).to eql("group")
+  end
+
+  it "loads the groups" do
+    expect(described_class.groups).to eql(groups)
+  end
+
+  it "loads the raw rules" do
+    groups.each do |key|
+      expect(described_class.raw_rules).to have_key(key)
+    end
+  end
+
+  it "determines the file path" do
+    path = described_class.file_path
+    expect(File.exists?(path)).to eql(true)
+  end
+
+  it "loads a rule by tag" do
+    rule = described_class.find_by_tag("commercial-use")
+    expect(rule).to be_a(described_class)
+    expect(rule.tag).to eql("commercial-use")
+  end
+
+  it "loads all rules" do
+    expect(described_class.all.count).to eql(13)
+    rule = described_class.all.first
+    expect(rule).to be_a(described_class)
+    expect(rule.tag).to eql("commercial-use")
+  end
+end

--- a/vendor/choosealicense.com/_data/fields.yml
+++ b/vendor/choosealicense.com/_data/fields.yml
@@ -1,0 +1,23 @@
+# The licenses on choosealicense.com are regularly imported to GitHub.com to
+# be used as the list of licenses available when creating a repository. When
+# we create a repository, we will replace certain strings in the license with
+# variables from the repository. These can be used to create accurate copyright
+# notices. The available variables are:
+
+- name: fullname
+  description: The full name or username of the repository owner
+
+- name: login
+  description: The repository owner's username
+
+- name: email
+  description: The repository owner's primary email address
+
+- name: project
+  description: The repository name
+
+- name: description
+  description: The description of the repository
+
+- name: year
+  description: The current year

--- a/vendor/choosealicense.com/_data/meta.yml
+++ b/vendor/choosealicense.com/_data/meta.yml
@@ -1,0 +1,60 @@
+# Each license has YAML front matter describing the license's properties.
+# The available fields are:
+
+- name: title
+  description: The license full name specified by http://spdx.org/licenses/
+  required: true
+
+- name: spdx-id
+  description: Short identifier specified by http://spdx.org/licenses/
+  required: required
+
+- name: source
+  description: The URL to the license source text
+  required: true
+
+- name: description
+  description: A human-readable description of the license
+  required: true
+
+- name: how
+  description: Instructions on how to implement the license
+  required: true
+
+- name: conditions
+  description: Bulleted list of required rules
+  required: true
+
+- name: permissions
+  description: Bulleted list of permitted rules
+  required: true
+
+- name: limitations
+  description: Bulleted list of limited rules
+  required: true
+
+# Optional fields
+
+- name: featured
+  description: Whether the license should be featured on the main page (defaults to false)
+  required: false
+
+- name: hidden
+  description: Whether the license is hidden from the license list (defaults to true)
+  required: false
+
+- name: nickname
+  description: Customary short name if applicable (e.g, GPLv3)
+  required: false
+
+- name: note
+  description: Additional information about the licenses
+  required: false
+
+- name: using
+  description: 'A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license_file_url`'
+  required: false
+
+- name: redirect_from
+  description: Relative path(s) to redirect to the license from, to prevent breaking old URLs
+  required: false

--- a/vendor/choosealicense.com/_data/rules.yml
+++ b/vendor/choosealicense.com/_data/rules.yml
@@ -1,0 +1,44 @@
+permissions:
+- description: This software and derivatives may be used for commercial purposes.
+  label: Commercial Use
+  tag: commercial-use
+- description: This software may be modified.
+  label: Modification
+  tag: modifications
+- description: You may distribute this software.
+  label: Distribution
+  tag: distribution
+- description: You may use and modify the software without distributing it.
+  label: Private Use
+  tag: private-use
+- description: This license provides an express grant of patent rights from the contributor to the recipient.
+  label: Patent Use
+  tag: patent-use
+
+conditions:
+- description: Include a copy of the license and copyright notice with the code.
+  label: License and Copyright Notice
+  tag: include-copyright
+- description: Indicate changes made to the code.
+  label: State Changes
+  tag: document-changes
+- description: Source code must be made available when distributing the software.
+  label: Disclose Source
+  tag: disclose-source
+- description: Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
+  label: Network Use is Distribution
+  tag: network-use-disclose
+- description: Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used.
+  label: Same License
+  tag: same-license
+
+limitations:
+- description: This license explicitly states that it does NOT grant you trademark rights, even though licenses without such a statement probably do not grant you any implicit trademark rights.
+  label: Trademark Use
+  tag: trademark-use
+- description: Software is provided without warranty and the software author/license owner cannot be held liable for damages.
+  label: Hold Liable
+  tag: no-liability
+- description: This license explicitly states that it does NOT grant you any rights in the patents of contributors.
+  label: Patent Use
+  tag: patent-use


### PR DESCRIPTION
This PR introduces a new `Licensee::Rule` class, which contains the tag, label, and description of the coresponding choosealicense.com rule.


Right now, you can call, e.g., `license["permissions"]`, but that returns the rule *tag*, e.g., `commercial-use`, but there is no way to get the human-readable label or description.

The idea is, with this PR, you can call `license.rules` to get a hash of rule objects describing what you can and can't do with the license in human-readable terms suitable for output in a UI similar to what we do on choosealicense.com, e.g., `license.rules.each { |rule| echo rule.label }`.

For this to work, we'll begin vendoring choosealicense.com's `_data` folder, so we can get the rule label and descriptions.

/cc @mlinksva, @bkeepers 
