### PR TITLE
Add support to match copyright with a full sentence

### DIFF
--- a/lib/licensee/matchers/copyright_matcher.rb
+++ b/lib/licensee/matchers/copyright_matcher.rb
@@ -5,7 +5,7 @@ module Licensee
       attr_reader :file
 
       # rubocop:disable Metrics/LineLength
-      REGEX = /\s*(Copyright|\(c\)) (©|\(c\)|\xC2\xA9)? ?(\d{4}|\[year\])(.*)?\s*/i
+      REGEX = /\s*(This software is )?([Cc]opyright|\(c\)) (©|\(c\)|\xC2\xA9)? ?(\d{4}|\[year\])(.*)?\s*/i
 
       def initialize(file)
         @file = file

--- a/spec/licensee/matchers/copyright_matcher_spec.rb
+++ b/spec/licensee/matchers/copyright_matcher_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Licensee::Matchers::Copyright do
     'Hyphen-separated date' => 'Copyright (c) 2003-2004 Ben Balter',
     'ASCII-8BIT encoded'    => "Copyright \xC2\xA92015 Ben Balter`"
       .force_encoding('ASCII-8BIT'),
-    'Full sentence'         => 'This software is copyright (c) 2016 by John Smith.',
+    'Full sentence'         => 
+	'This software is copyright (c) 2016 by John Smith.'
   }.each do |description, notice|
     context "with a #{description} notice" do
       let(:content) { notice }

--- a/spec/licensee/matchers/copyright_matcher_spec.rb
+++ b/spec/licensee/matchers/copyright_matcher_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Licensee::Matchers::Copyright do
     'Comma-separated date'  => 'Copyright (c) 2003, 2004 Ben Balter',
     'Hyphen-separated date' => 'Copyright (c) 2003-2004 Ben Balter',
     'ASCII-8BIT encoded'    => "Copyright \xC2\xA92015 Ben Balter`"
-      .force_encoding('ASCII-8BIT')
+      .force_encoding('ASCII-8BIT'),
+    'Full sentence'         => 'This software is copyright (c) 2016 by John Smith.',
   }.each do |description, notice|
     context "with a #{description} notice" do
       let(:content) { notice }

--- a/spec/licensee/matchers/copyright_matcher_spec.rb
+++ b/spec/licensee/matchers/copyright_matcher_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Licensee::Matchers::Copyright do
     'Hyphen-separated date' => 'Copyright (c) 2003-2004 Ben Balter',
     'ASCII-8BIT encoded'    => "Copyright \xC2\xA92015 Ben Balter`"
       .force_encoding('ASCII-8BIT'),
-    'Full sentence'         => 
-	'This software is copyright (c) 2016 by John Smith.'
+    'Full sentence'         => 'This software is copyright (c) 2016 by '\
+      'John Smith.'
   }.each do |description, notice|
     context "with a #{description} notice" do
       let(:content) { notice }


### PR DESCRIPTION
Some projects have a full sentence for the copyright. For example this [LICENSE file](https://github.com/moose/Class-Load/blob/master/LICENSE) (It's common in Perl modules, specially those minted with [Dist::Zilla](https://metacpan.org/pod/Dist::Zilla))

When this sentence is not matched by the copyright matcher, the license in LICENSE file it's harder to guess for licensee. If this sentence is treated as the copyright licensee can do a better work guessing the license.
