### PR TITLE
Drop active support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-group :test do
-  # Active support >= 5 requires Ruby > 2.2
-  gem 'activesupport', '< 5'
-end


### PR DESCRIPTION
In support of https://github.com/benbalter/licensee/pull/151.

It doesn't look like ActiveSupport is used. It was added via https://github.com/benbalter/licensee/pull/107, but at least locally, tests pass without it being bundled. I suspect it was a remnant of an alternate approach to testing.

/cc @connorshea 
