### PR TITLE
Add dist.ini file matcher for Perl modules using Dist::Zilla

### DIFF
--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -22,6 +22,7 @@ require_relative 'licensee/matchers/package_matcher'
 require_relative 'licensee/matchers/gemspec_matcher'
 require_relative 'licensee/matchers/npm_bower_matcher'
 require_relative 'licensee/matchers/cran_matcher'
+require_relative 'licensee/matchers/dist_zilla_matcher'
 
 module Licensee
   # Over which percent is a match considered a match by default

--- a/lib/licensee/matchers/dist_zilla_matcher.rb
+++ b/lib/licensee/matchers/dist_zilla_matcher.rb
@@ -12,30 +12,11 @@ module Licensee
         spdx_name(match[1]).downcase if match && match[1]
       end
 
-      CONVERT_PERL_LICENSE_NAME_TO_SPDX_NAME = {
-        'AGPL_3'       => 'AGPL-3.0',
-        'Apache_1_1'   => 'Apache-1.1',
-        'Apache_2_0'   => 'Apache-2.0',
-        'Artistic_1_0' => 'Artistic-1.0',
-        'Artistic_2_0' => 'Artistic-2.0',
-        'CC0_1_0'      => 'CC0-1.0',
-        'GFDL_1_2'     => 'GFDL-1.2',
-        'GFDL_1_3'     => 'GFDL-1.3',
-        'GPL_1'        => 'GPL-1.0',
-        'GPL_2'        => 'GPL-2.0',
-        'GPL_3'        => 'GPL-3.0',
-        'LGPL_2_1'     => 'LGPL-2.1',
-        'LGPL_3_0'     => 'LGPL-3.0',
-        'Mozilla_1_0'  => 'MPL-1.0',
-        'Mozilla_1_1'  => 'MPL-1.1',
-        'Mozilla_2_0'  => 'MPL-2.0',
-        'QPL_1_0'      => 'QPL-1.0'
-      }.freeze
-
       def spdx_name(perl_name)
-        spdx = CONVERT_PERL_LICENSE_NAME_TO_SPDX_NAME[perl_name]
-        return spdx if spdx
-        perl_name
+        perl_name.sub('_', '-')
+                 .sub('_', '.')
+                 .sub('Mozilla', 'MPL')
+                 .sub(/^GPL-(\d)$/, 'GPL-\1.0')
       end
     end
   end

--- a/lib/licensee/matchers/dist_zilla_matcher.rb
+++ b/lib/licensee/matchers/dist_zilla_matcher.rb
@@ -3,13 +3,39 @@ module Licensee
     class DistZilla < Package
       attr_reader :file
 
-      LICENSE_REGEX = /^license\s*=\s*([a-z\-0-9_]+)/i
+      LICENSE_REGEX = /^license\s*=\s*([a-z\-0-9\._]+)/i
 
       private
 
       def license_property
         match = file.content.match LICENSE_REGEX
-        match[1].downcase if match && match[1]
+        spdx_name(match[1]).downcase if match && match[1]
+      end
+
+      CONVERT_PERL_LICENSE_NAME_TO_SPDX_NAME = {
+        'AGPL_3'       => 'AGPL-3.0',
+        'Apache_1_1'   => 'Apache-1.1',
+        'Apache_2_0'   => 'Apache-2.0',
+        'Artistic_1_0' => 'Artistic-1.0',
+        'Artistic_2_0' => 'Artistic-2.0',
+        'CC0_1_0'      => 'CC0-1.0',
+        'GFDL_1_2'     => 'GFDL-1.2',
+        'GFDL_1_3'     => 'GFDL-1.3',
+        'GPL_1'        => 'GPL-1.0',
+        'GPL_2'        => 'GPL-2.0',
+        'GPL_3'        => 'GPL-3.0',
+        'LGPL_2_1'     => 'LGPL-2.1',
+        'LGPL_3_0'     => 'LGPL-3.0',
+        'Mozilla_1_0'  => 'MPL-1.0',
+        'Mozilla_1_1'  => 'MPL-1.1',
+        'Mozilla_2_0'  => 'MPL-2.0',
+        'QPL_1_0'      => 'QPL-1.0'
+      }.freeze
+
+      def spdx_name(perl_name)
+        spdx = CONVERT_PERL_LICENSE_NAME_TO_SPDX_NAME[perl_name]
+        return spdx if spdx
+        perl_name
       end
     end
   end

--- a/lib/licensee/matchers/dist_zilla_matcher.rb
+++ b/lib/licensee/matchers/dist_zilla_matcher.rb
@@ -3,9 +3,7 @@ module Licensee
     class DistZilla < Package
       attr_reader :file
 
-      LICENSE_REGEX = /
-        ^license\s*=\s*([a-z\-0-9\.]+)
-      /ix
+      LICENSE_REGEX = /^license\s*=\s*([a-z\-0-9_]+)/i
 
       private
 

--- a/lib/licensee/matchers/dist_zilla_matcher.rb
+++ b/lib/licensee/matchers/dist_zilla_matcher.rb
@@ -8,7 +8,7 @@ module Licensee
       private
 
       def license_property
-        match = @file.content.match LICENSE_REGEX
+        match = file.content.match LICENSE_REGEX
         match[1].downcase if match && match[1]
       end
     end

--- a/lib/licensee/matchers/dist_zilla_matcher.rb
+++ b/lib/licensee/matchers/dist_zilla_matcher.rb
@@ -1,0 +1,18 @@
+module Licensee
+  module Matchers
+    class DistZilla < Package
+      attr_reader :file
+
+      LICENSE_REGEX = /
+        ^license\s*=\s*([a-z\-0-9\.]+)
+      /ix
+
+      private
+
+      def license_property
+        match = @file.content.match LICENSE_REGEX
+        match[1].downcase if match && match[1]
+      end
+    end
+  end
+end

--- a/lib/licensee/project_files/package_info.rb
+++ b/lib/licensee/project_files/package_info.rb
@@ -21,8 +21,8 @@ module Licensee
       def self.name_score(filename)
         return 1.0  if ::File.extname(filename) == '.gemspec'
         return 1.0  if filename == 'package.json'
-        return 0.95 if filename == 'dist.ini'
         return 0.9  if filename == 'DESCRIPTION'
+        return 0.8  if filename == 'dist.ini'
         return 0.75 if filename == 'bower.json'
         0.0
       end

--- a/lib/licensee/project_files/package_info.rb
+++ b/lib/licensee/project_files/package_info.rb
@@ -10,6 +10,8 @@ module Licensee
         else
           if filename == 'DESCRIPTION' && content.start_with?('Package:')
             [Matchers::Cran]
+          elsif filename == 'dist.ini'
+            [Matchers::DistZilla]
           else
             []
           end
@@ -19,6 +21,7 @@ module Licensee
       def self.name_score(filename)
         return 1.0  if ::File.extname(filename) == '.gemspec'
         return 1.0  if filename == 'package.json'
+        return 0.95 if filename == 'dist.ini'
         return 0.9  if filename == 'DESCRIPTION'
         return 0.75 if filename == 'bower.json'
         0.0

--- a/lib/licensee/project_files/package_info.rb
+++ b/lib/licensee/project_files/package_info.rb
@@ -21,8 +21,8 @@ module Licensee
       def self.name_score(filename)
         return 1.0  if ::File.extname(filename) == '.gemspec'
         return 1.0  if filename == 'package.json'
-        return 0.9  if filename == 'DESCRIPTION'
         return 0.8  if filename == 'dist.ini'
+        return 0.9  if filename == 'DESCRIPTION'
         return 0.75 if filename == 'bower.json'
         0.0
       end

--- a/spec/licensee/matchers/dist_zilla_matcher_spec.rb
+++ b/spec/licensee/matchers/dist_zilla_matcher_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Licensee::Matchers::DistZilla do
+  let(:mit) { Licensee::License.find('mit') }
+  let(:content) { 'license = MIT' }
+  let(:file) { Licensee::Project::LicenseFile.new(content, 'dist.ini') }
+  subject { described_class.new(file) }
+
+  it 'stores the file' do
+    expect(subject.file).to eql(file)
+  end
+
+  it 'has confidence' do
+    expect(subject.confidence).to eql(90)
+  end
+
+  it 'matches' do
+    expect(subject.match).to eql(mit)
+  end
+end

--- a/spec/licensee/matchers/dist_zilla_matcher_spec.rb
+++ b/spec/licensee/matchers/dist_zilla_matcher_spec.rb
@@ -15,4 +15,19 @@ RSpec.describe Licensee::Matchers::DistZilla do
   it 'matches' do
     expect(subject.match).to eql(mit)
   end
+
+  {
+    'spdx name'     => ["license = MIT", 'mit'],
+    'non spdx name' => ['license = Mozilla_2_0', 'mpl-2.0'],
+  }.each do |description, license_declaration_and_key|
+    context "with a #{description}" do
+      let(:content) { license_declaration_and_key[0] }
+      let(:license) { Licensee::License.find(license_declaration_and_key[1]) }
+
+      it 'matches' do
+        expect(subject.match).to eql(license)
+      end
+    end
+  end
+
 end

--- a/spec/licensee/matchers/dist_zilla_matcher_spec.rb
+++ b/spec/licensee/matchers/dist_zilla_matcher_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Licensee::Matchers::DistZilla do
   end
 
   {
-    'spdx name'     => ["license = MIT", 'mit'],
-    'non spdx name' => ['license = Mozilla_2_0', 'mpl-2.0'],
+    'spdx name'     => ['license = MIT', 'mit'],
+    'non spdx name' => ['license = Mozilla_2_0', 'mpl-2.0']
   }.each do |description, license_declaration_and_key|
     context "with a #{description}" do
       let(:content) { license_declaration_and_key[0] }
@@ -29,5 +29,4 @@ RSpec.describe Licensee::Matchers::DistZilla do
       end
     end
   end
-
 end

--- a/spec/licensee/project_files/package_info_spec.rb
+++ b/spec/licensee/project_files/package_info_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Licensee::Project::PackageInfo do
     {
       'licensee.gemspec' => 1.0,
       'package.json'     => 1.0,
+      'dist.ini'         => 0.95,
       'DESCRIPTION'      => 0.9,
       'bower.json'       => 0.75,
       'README.md'        => 0.0
@@ -36,6 +37,14 @@ RSpec.describe Licensee::Project::PackageInfo do
 
       it 'returns the gemspec matcher' do
         expect(possible_matchers).to eql([Licensee::Matchers::NpmBower])
+      end
+    end
+
+    context 'with dist.ini' do
+      let(:filename) { 'dist.ini' }
+
+      it 'returns the DistZilla matcher' do
+        expect(possible_matchers).to eql([Licensee::Matchers::DistZilla])
       end
     end
 

--- a/spec/licensee/project_files/package_info_spec.rb
+++ b/spec/licensee/project_files/package_info_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Licensee::Project::PackageInfo do
     {
       'licensee.gemspec' => 1.0,
       'package.json'     => 1.0,
-      'dist.ini'         => 0.95,
       'DESCRIPTION'      => 0.9,
+      'dist.ini'         => 0.8,
       'bower.json'       => 0.75,
       'README.md'        => 0.0
     }.each do |filename, expected_score|


### PR DESCRIPTION
As suggested in the [Pull request 150](https://github.com/benbalter/licensee/pull/150#issuecomment-270140145) I've implemented a file matcher for Perl modules using [Dist::Zilla](http://dzil.org/) using the CRAN matcher as template.

A lot of Perl modules using Dist::Zilla ([with a `dist.ini` file](https://github.com/search?utf8=%E2%9C%93&q=filename%3Adist.ini+path%3A%2F)) don't put a LICENSE file under version control because it's autogenerated
