### PR TITLE
Update range of linked lines in docs

### DIFF
--- a/docs/what-we-look-at.md
+++ b/docs/what-we-look-at.md
@@ -4,7 +4,7 @@ Licensee works by taking a detected license file, and comparing the contents to 
 
 ## Detecting the license file
 
-Licensee uses [a series of regular expressions](https://github.com/benbalter/licensee/blob/master/lib/licensee/project_files/license_file.rb#L15-L25) to score files in the project's root as potential license files. Here's a few examples of files that would be detected:
+Licensee uses [a series of regular expressions](https://github.com/benbalter/licensee/blob/master/lib/licensee/project_files/license_file.rb#L20-L30) to score files in the project's root as potential license files. Here's a few examples of files that would be detected:
 
 * `LICENSE`
 * `LICENCE`


### PR DESCRIPTION
`license_file.rb` was edited since the link was first made, so the range pointed to the wrong part of the file. With this change, the range once again cover the `FILENAME_REGEXES` hash contents.