### PR TITLE
docs/what-we-look-at: Remove "Is it GPLv2? GPLv2 or later?"

### DIFF
--- a/docs/what-we-look-at.md
+++ b/docs/what-we-look-at.md
@@ -33,9 +33,7 @@ Because reasons.
 
 Because it's not legally binding. A license is a legal contract. You give up certain rights (e.g., the right to sue the author) in exchange for the right to use the software.
 
-Most popular licenses today *require* that the license itself be distributed along side the software. Simply putting the letters "MIT" or "GPL" in a configuration file doesn't really meet that requirement.
-
-Not to mention, it doesn't tell you much about your rights as a user. Is it GPLv2? GPLv2 or later? Those files are designed to be read by computers (who can't enter into contracts), not humans (who can). It's great metadata, but that's about it.
+Most popular licenses today *require* that the license itself be distributed along side the software. Simply putting the letters "MIT" or "GPL" in a configuration file doesn't really meet that requirement. Those files are designed to be read by computers (who can't enter into contracts), not humans (who can). It's great metadata, but that's about it.
 
 ### What about looking to see if the author said something in the readme?
 


### PR DESCRIPTION
Some packaging systems allow you to make these distinctions.  For example, Python supports [“or later” Trove classifiers][1], including `License :: OSI Approved :: GNU General Public License v2 (GPLv2)` and `License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)`.  npm [allows SPDX license expression syntax v2.0][2] (and [SPDX expressions support `+`, e.g. `GPL-2.0+`][3]).

The point of this paragraph is that such an entry is metadata which may not be sufficiently binding (#4), while including the full license text is much more likely to be legally binding.  By removing the FUD about “cannot distinguish between GPL-2.0 and GPL-2.0+”, we can focus on the point that actually matters.

[1]: https://pypi.python.org/pypi?%3Aaction=list_classifiers
[2]: https://docs.npmjs.com/files/package.json#license
[3]: https://spdx.org/sites/cpstandard/files/pages/files/spdx-2.0.pdf#page=82
[4]: https://github.com/benbalter/licensee/issues/4