### PR TITLE
Anchor attribution detection to the first normalized line

### DIFF
--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -45,7 +45,7 @@ module Licensee
 
     # Content with the title and version removed
     # The first time should normally be the attribution line
-    # Used to try up `content_normalized` but we need the case sensitive
+    # Used to dry up `content_normalized` but we need the case sensitive
     # content with attribution first to detect attribuion in LicenseFile
     def content_without_title_and_version
       @content_without_title_and_version ||= begin

--- a/lib/licensee/matchers/copyright_matcher.rb
+++ b/lib/licensee/matchers/copyright_matcher.rb
@@ -6,7 +6,7 @@ module Licensee
 
       # rubocop:disable Metrics/LineLength
       COPYRIGHT_SYMBOLS = Regexp.union([/copyright/i, /\(c\)/i, "\u00A9", "\xC2\xA9"])
-      REGEX = /^\s*#{COPYRIGHT_SYMBOLS}.*$/i
+      REGEX = /\A\s*#{COPYRIGHT_SYMBOLS}.*$/i
       # rubocop:enable Metrics/LineLength
 
       def initialize(file)

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -40,8 +40,11 @@ module Licensee
       end
 
       def attribution
-        matches = /^#{Matchers::Copyright::REGEX}$/i.match(content)
-        matches[0].strip if matches
+        @attribution ||= begin
+          matches = /\A#{Matchers::Copyright::REGEX}$/i
+                    .match(content_without_title_and_version)
+          matches[0] if matches
+        end
       end
 
       # Is this file likely to result in a creative commons false positive?

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -41,7 +41,7 @@ module Licensee
 
       def attribution
         @attribution ||= begin
-          matches = /\A#{Matchers::Copyright::REGEX}$/i
+          matches = Matchers::Copyright::REGEX
                     .match(content_without_title_and_version)
           matches[0] if matches
         end

--- a/spec/licensee/content_helper_spec.rb
+++ b/spec/licensee/content_helper_spec.rb
@@ -74,13 +74,17 @@ RSpec.describe Licensee::ContentHelper do
 
     Licensee::License.all(hidden: true).each do |license|
       context license.name do
+        let(:stripped_content) { subject.content_without_title_and_version }
+
         it 'strips the title' do
           regex = /\A#{license.name_without_version}/i
           expect(license.content_normalized).to_not match(regex)
+          expect(stripped_content).to_not match(regex)
         end
 
         it 'strips the version' do
           expect(license.content_normalized).to_not match(/\Aversion/i)
+          expect(stripped_content).to_not match(/\Aversion/i)
         end
 
         it 'strips the copyright' do

--- a/spec/licensee/project_files/license_file_spec.rb
+++ b/spec/licensee/project_files/license_file_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Licensee::Project::LicenseFile do
     expect(subject.attribution).to eql('Copyright (c) 2016 Ben Balter')
   end
 
+  context "when there's a random copyright-like line" do
+    let(:content) { "Foo\nCopyright 2016 Ben Balter\nBar" }
+
+    it "doesn't match" do
+      expect(subject.attribution).to be_nil
+    end
+  end
+
   context 'with an non-UTF-8-encoded license' do
     let(:content) { "\x91License\x93".force_encoding('windows-1251') }
 


### PR DESCRIPTION
Fixes https://github.com/benbalter/licensee/issues/169.

This PR changes the way attribution is detected by anchoring the attribution detection to the start of the file, rather than the start of a line. It avoid situations where we properly detect a license, but `LicenseFile.attribution` comes back as a random line starting with the word Copyright.

In order to do this, the title stripping is now case insensitive so that we can strip the title and version and still get the properly cased attribution.

```
➜  licensee git:(master) ✗ script/git-repo https://github.com/github/open-source-guide
License file: LICENSE
License hash: bec83478a124efb1beb8500ee952ffcc80a87b2b
License: Creative Commons Attribution 4.0
Confidence: 100.00%
Method: Licensee::Matchers::Dice
```

/cc @mlinksva 