### PR TITLE
Properly remove BSD titles when normalizing licenses

### DIFF
--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -5,6 +5,11 @@ module Licensee
   module ContentHelper
     DIGEST = Digest::SHA1
     END_OF_TERMS_REGEX = /^\s*end of terms and conditions\s*$/i
+    ALT_TITLE_REGEX = {
+      'bsd-2-clause'       => /bsd 2-clause( \"simplified\")? license/i,
+      'bsd-3-clause'       => /bsd 3-clause( \"new\" or \"revised\")? license/i,
+      'bsd-3-clause-clear' => /bsd 3-clause( clear)? license/i
+    }.freeze
 
     # A set of each word in the license, without duplicates
     def wordset
@@ -73,7 +78,8 @@ module Licensee
 
     def license_names
       @license_titles ||= License.all(hidden: true).map do |license|
-        license.name_without_version.downcase.sub('*', 'u')
+        regex = ALT_TITLE_REGEX[license.key]
+        regex || license.name_without_version.downcase.sub('*', 'u')
       end
     end
 

--- a/spec/licensee/content_helper_spec.rb
+++ b/spec/licensee/content_helper_spec.rb
@@ -78,7 +78,8 @@ EOS
         let(:stripped_content) { subject.content_without_title_and_version }
 
         it 'strips the title' do
-          regex = /\A#{license.name_without_version}/i
+          regex = Licensee::ContentHelper::ALT_TITLE_REGEX[license.key]
+          regex ||= /\A#{license.name_without_version}/i
           expect(license.content_normalized).to_not match(regex)
           expect(stripped_content).to_not match(regex)
         end


### PR DESCRIPTION
BSD licenses have nicknames e.g., "Simplified" or "Clear" that appear in the license title metadata, but not in the license file itself. As such, since the metadata title and in-license title don't match, the title isn't being stripped when the content is normalized.

This PR special cases the three BSD licenses with a regex that takes into account the nicknames, making the nickname optional when checking if the first line is the title.

Fixes https://github.com/benbalter/licensee/issues/173.