### PR TITLE
Look up license rule by tag and group

### DIFF
--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -143,7 +143,9 @@ module Licensee
       @rules = {}
 
       Rule.groups.each do |group|
-        @rules[group] = meta[group].map { |tag| Rule.find_by_tag(tag) }
+        @rules[group] = meta[group].map do |tag|
+          Rule.find_by_tag_and_group(tag, group)
+        end
       end
 
       @rules

--- a/lib/licensee/rule.rb
+++ b/lib/licensee/rule.rb
@@ -27,9 +27,10 @@ module Licensee
         end.flatten
       end
 
-      def find_by_tag(tag)
-        Rule.all.find { |r| r.tag == tag }
+      def find_by_tag_and_group(tag, group = nil)
+        Rule.all.find { |r| r.tag == tag && (group.nil? || r.group == group) }
       end
+      alias find_by_tag find_by_tag_and_group
 
       def file_path
         dir = File.dirname(__FILE__)

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -232,4 +232,11 @@ RSpec.describe Licensee::License do
     expect(mit.rules['permissions'].first).to be_a(Licensee::Rule)
     expect(mit.rules.flatten.count).to eql(6)
   end
+
+  it 'returns rules by tag and group' do
+    expect(cc_by.rules).to have_key('limitations')
+    rule = cc_by.rules['limitations'].find { |r| r.tag == 'patent-use' }
+    expect(rule).to_not be_nil
+    expect(rule.description).to include('does NOT grant')
+  end
 end

--- a/spec/licensee/rule_spec.rb
+++ b/spec/licensee/rule_spec.rb
@@ -36,8 +36,15 @@ RSpec.describe Licensee::Rule do
     expect(rule.tag).to eql('commercial-use')
   end
 
+  it 'loads a rule by tag and group' do
+    rule = described_class.find_by_tag_and_group('patent-use', 'limitations')
+    expect(rule).to be_a(described_class)
+    expect(rule.tag).to eql('patent-use')
+    expect(rule.description).to include('does NOT grant')
+  end
+
   it 'loads all rules' do
-    expect(described_class.all.count).to eql(13)
+    expect(described_class.all.count).to eql(16)
     rule = described_class.all.first
     expect(rule).to be_a(described_class)
     expect(rule.tag).to eql('commercial-use')


### PR DESCRIPTION
This fixes the case of `patent-use` under limitations for CC licenses showing the wrong description by looking up license rules by both tag and group, not just tag. 

We previously assumed rule tags were globally unique. They're only unique to the group.

We also weren't running the rule spec apparently due to the file name (although tests mostly passed).