### PR TITLE
Anchor cc-by-nd false positive detection to start of line, not start of file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,6 @@ Metrics/ClassLength:
 
 Metrics/AbcSize:
   Enabled: false
+
+Style/IndentHeredoc:
+  Enabled: false

--- a/lib/licensee/matchers/copyright_matcher.rb
+++ b/lib/licensee/matchers/copyright_matcher.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 module Licensee
   module Matchers
     class Copyright

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -32,7 +32,7 @@ module Licensee
       # CC-NC and CC-ND are not open source licenses and should not be
       # detected as CC-BY or CC-BY-SA which are 98%+ similar
       CC_FALSE_POSITIVE_REGEX = /
-        \A(creative\ commons\ )?Attribution-(NonCommercial|NoDerivatives)
+        ^(creative\ commons\ )?Attribution-(NonCommercial|NoDerivatives)
       /xi
 
       def possible_matchers

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Licensee::License do
       end
 
       it "doesn't include hidden licenses" do
-        expect(licenses).to all satisfy { |license| !license.hidden? }
+        expect(licenses).to all(satisfy { |license| !license.hidden? })
       end
 
       it 'includes featured licenses' do

--- a/spec/licensee/project_files/license_file_spec.rb
+++ b/spec/licensee/project_files/license_file_spec.rb
@@ -162,5 +162,20 @@ RSpec.describe Licensee::Project::LicenseFile do
         expect(subject).to be_a_potential_false_positive
       end
     end
+
+    context 'CC-BY-ND with leading instructions' do
+      let(:content) do
+        <<-EOS
+Creative Commons Corporation ("Creative Commons") is not a law firm
+======================================================================
+Creative Commons Attribution-NonCommercial 4.0
+        EOS
+      end
+
+      it "knows it's a potential false positive" do
+        expect(subject.content).to match(regex)
+        expect(subject).to be_a_potential_false_positive
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/benbalter/licensee/issues/180.

The linked license contains the license instructions, which do not appear to be part of the official license text.

Compare https://github.com/facebookresearch/visdom/blob/master/LICENSE with https://creativecommons.org/licenses/by-nc/4.0/legalcode.txt.

We want all our other regexes to be as strict as possible to avoid false positive, but since this regex itself is designed to detect potential false positives, we actually want it to be as lenient as possible.

Swapping `\A` for `^` should match the license, even if it has the instructions included.
