### PR TITLE
Resolve lint errors

### DIFF
--- a/lib/licensee/matchers/copyright_matcher.rb
+++ b/lib/licensee/matchers/copyright_matcher.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 module Licensee
   module Matchers
     class Copyright

--- a/spec/licensee/content_helper_spec.rb
+++ b/spec/licensee/content_helper_spec.rb
@@ -9,14 +9,14 @@ end
 
 RSpec.describe Licensee::ContentHelper do
   let(:content) do
-    <<-EOS.freeze
-The MIT License
+    <<-EOS.freeze.gsub(/^\s*/, '')
+  The MIT License
 
-Copyright 2016 Ben Balter
+  Copyright 2016 Ben Balter
 
-The made
-up  license.
------------
+  The made
+  up  license.
+  -----------
 EOS
   end
   subject { ContentHelperTestHelper.new(content) }

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Licensee::License do
       end
 
       it "doesn't include hidden licenses" do
-        expect(licenses).to all satisfy { |license| !license.hidden? }
+        expect(licenses).to all(satisfy { |license| !license.hidden? })
       end
 
       it 'includes featured licenses' do


### PR DESCRIPTION
This resolves the current build failure. I'm new to Ruby and resolving the requirement for heredoc to be indented wasn't pretty, pulling in a new dependency seemed like overkill so used the ```gsub``` solution from http://stackoverflow.com/questions/3772864/how-do-i-remove-leading-whitespace-chars-from-ruby-heredoc.