### PR TITLE
Expanded support for standard files declaring the font under OFL. 

### DIFF
--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -17,22 +17,22 @@ module Licensee
       COPYING_REGEX = /copy(ing|right)/i
 
       # Regex to match OFL.
-      OFL_REGEX = /OFL(.txt|.md)/i
+      OFL_REGEX = /ofl/i
 
       # Hash of Regex => score with which to score potential license files
       FILENAME_REGEXES = {
-        /\A#{LICENSE_REGEX}\z/                       => 1.0, # LICENSE
-        /\A#{LICENSE_REGEX}#{PREFERRED_EXT_REGEX}\z/ => 0.9, # LICENSE.md
-        /\A#{COPYING_REGEX}\z/                       => 0.8, # COPYING
-        /\A#{COPYING_REGEX}#{PREFERRED_EXT_REGEX}\z/ => 0.7, # COPYING.md
-        /\A#{LICENSE_REGEX}#{ANY_EXT_REGEX}\z/       => 0.6, # LICENSE.textile
-        /\A#{COPYING_REGEX}#{ANY_EXT_REGEX}\z/       => 0.5, # COPYING.textile
-        /#{LICENSE_REGEX}/                           => 0.4, # LICENSE-MIT
-        /#{COPYING_REGEX}/                           => 0.3, # COPYING-MIT
-        /#{OFL_REGEX}/                               => 0.5, # OFL.txt
-        /OFL#{ANY_EXT_REGEX}/                        => 0.4, # OFL.md
-        /OFL#{PREFERRED_EXT_REGEX}/                  => 0.3, # OFL
-        //                                           => 0.0  # Catch all
+        /\A#{LICENSE_REGEX}\z/                       => 1.0,  # LICENSE
+        /\A#{LICENSE_REGEX}#{PREFERRED_EXT_REGEX}\z/ => 0.9,  # LICENSE.md
+        /\A#{COPYING_REGEX}\z/                       => 0.8,  # COPYING
+        /\A#{COPYING_REGEX}#{PREFERRED_EXT_REGEX}\z/ => 0.7,  # COPYING.md
+        /\A#{LICENSE_REGEX}#{ANY_EXT_REGEX}\z/       => 0.6,  # LICENSE.textile
+        /\A#{COPYING_REGEX}#{ANY_EXT_REGEX}\z/       => 0.5,  # COPYING.textile
+        /#{LICENSE_REGEX}/                           => 0.4,  # LICENSE-MIT
+        /#{COPYING_REGEX}/                           => 0.3,  # COPYING-MIT
+        /\A#{OFL_REGEX}#{PREFERRED_EXT_REGEX}/       => 0.2,  # OFL.md
+        /\A#{OFL_REGEX}#{ANY_EXT_REGEX}/             => 0.1,  # OFL.textile
+        /\A#{OFL_REGEX}\z/                           => 0.05, # OFL
+        //                                           => 0.0   # Catch all
       }.freeze
 
       # CC-NC and CC-ND are not open source licenses and should not be

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -16,6 +16,10 @@ module Licensee
       # Regex to match COPYING, COPYRIGHT, etc.
       COPYING_REGEX = /copy(ing|right)/i
 
+      # Regex to match OFL.
+      OFL_REGEX = /OFL(.txt|.md)/i
+
+
       # Hash of Regex => score with which to score potential license files
       FILENAME_REGEXES = {
         /\A#{LICENSE_REGEX}\z/                       => 1.0, # LICENSE
@@ -26,6 +30,7 @@ module Licensee
         /\A#{COPYING_REGEX}#{ANY_EXT_REGEX}\z/       => 0.5, # COPYING.textile
         /#{LICENSE_REGEX}/                           => 0.4, # LICENSE-MIT
         /#{COPYING_REGEX}/                           => 0.3, # COPYING-MIT
+        /#{OFL_REGEX}/                               => 0.5, # OFL
         //                                           => 0.0  # Catch all
       }.freeze
 

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -19,7 +19,6 @@ module Licensee
       # Regex to match OFL.
       OFL_REGEX = /OFL(.txt|.md)/i
 
-
       # Hash of Regex => score with which to score potential license files
       FILENAME_REGEXES = {
         /\A#{LICENSE_REGEX}\z/                       => 1.0, # LICENSE
@@ -30,7 +29,9 @@ module Licensee
         /\A#{COPYING_REGEX}#{ANY_EXT_REGEX}\z/       => 0.5, # COPYING.textile
         /#{LICENSE_REGEX}/                           => 0.4, # LICENSE-MIT
         /#{COPYING_REGEX}/                           => 0.3, # COPYING-MIT
-        /#{OFL_REGEX}/                               => 0.5, # OFL
+        /#{OFL_REGEX}/                               => 0.5, # OFL.txt
+        /OFL#{ANY_EXT_REGEX}/                        => 0.4, # OFL.md
+        /OFL#{PREFERRED_EXT_REGEX}/                  => 0.3, # OFL
         //                                           => 0.0  # Catch all
       }.freeze
 

--- a/spec/licensee/project_files/license_file_spec.rb
+++ b/spec/licensee/project_files/license_file_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe Licensee::Project::LicenseFile do
       'mit-license-foo.md' => 0.4,
       'COPYING-GPL'        => 0.3,
       'COPYRIGHT-BSD'      => 0.3,
+      'OFL.md'             => 0.2,
+      'ofl.textile'        => 0.1,
+      'ofl'                => 0.05,
+      'not-the-ofl'        => 0.0,
       'README.txt'         => 0.0
     }.each do |filename, expected|
       context "a file named #{filename}" do


### PR DESCRIPTION
Many open fonts developed and released under OFL on GitHub are not detected properly by licensee.  A key feature of the license was naming the license file explicitly (instead of using the generic software filenames) so designers could recognize it more easily. 

Best practices across the open font design community is to use OFL.txt. 
Please add support for the standard filenames. 

I can see you have added already support the standards files like MIT.txt or MIT-license.txt. This is similar. 

Thanks. 