### PR TITLE
other pseudolicense if project had a license, but we were not able to detect it

### DIFF
--- a/bin/licensee
+++ b/bin/licensee
@@ -24,7 +24,7 @@ unless matched_file
 end
 
 if matched_file.license
-  puts "License: #{matched_file.license.meta['title']}"
+  puts "License: #{matched_file.license.name}"
 
   if matched_file.confidence
     puts "Confidence: #{format_percent(matched_file.confidence)}"

--- a/lib/licensee/matchers/package_matcher.rb
+++ b/lib/licensee/matchers/package_matcher.rb
@@ -6,7 +6,9 @@ module Licensee
       end
 
       def match
-        Licensee.licenses(hidden: true).find { |l| l.key == license_property }
+        Licensee.licenses(hidden: true)
+                .find { |l| l.key == license_property } ||
+          Licensee::License.find('other')
       end
 
       def confidence

--- a/lib/licensee/project.rb
+++ b/lib/licensee/project.rb
@@ -17,9 +17,14 @@ module Licensee
     end
 
     def matched_file
-      @matched_file ||= begin
-        [license_file, readme, package_file].compact.find(&:license)
+      return @matched_file if defined? @matched_file
+      other = nil
+      [license_file, readme, package_file].compact.each do |f|
+        next unless f.license
+        return @matched_file = f unless f.license.key == 'other'
+        other ||= f
       end
+      @matched_file = other
     end
 
     def license_file

--- a/lib/licensee/project_file.rb
+++ b/lib/licensee/project_file.rb
@@ -26,7 +26,7 @@ module Licensee
       end
 
       def license
-        matcher && matcher.match
+        (matcher && matcher.match) || Licensee::License.find('other')
       end
 
       alias match license

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe 'integration test' do
     context "with a #{project_type} project" do
       let(:filename) { 'LICENSE' }
       let(:license) { Licensee::License.find('mit') }
+      let(:other) { Licensee::License.find('other') }
       let(:content) { license.content }
       let(:license_path) { File.expand_path(filename, project_path) }
       let(:arguments) { {} }
@@ -40,16 +41,16 @@ RSpec.describe 'integration test' do
         context 'with CC-BY-NC-SA' do
           let(:fixture) { 'cc-by-nc-sa' }
 
-          it 'matches nothing' do
-            expect(subject.license).to eql(nil)
+          it 'matches other' do
+            expect(subject.license).to eql(other)
           end
         end
 
         context 'with CC-BY-ND' do
           let(:fixture) { 'cc-by-nd' }
 
-          it 'matches nothing' do
-            expect(subject.license).to eql(nil)
+          it 'matches other' do
+            expect(subject.license).to eql(other)
           end
         end
 
@@ -111,7 +112,7 @@ RSpec.describe 'integration test' do
           let(:content) { '' }
 
           it "doesn't match" do
-            expect(subject.license).to be_nil
+            expect(subject.license).to eql(other)
             expect(subject.license_file.path).to eql('LICENSE')
           end
         end


### PR DESCRIPTION
Noticed that there's an 'other' pseudo license documented at https://github.com/benbalter/licensee/blob/baf944b645e7d61e01bdb2f5b664362db0a9bf2b/lib/licensee/license.rb#L62 and wondered why it is never returned.

It's never used except in tests checking that it exists and has expected properties. Thought about filing an issue or PR removing the 'other' definition and tests, but decided to get to know the project better to try to make the code comment about 'other' ("project had a license, but we were not able to detect it") accurate. That's this PR, which is probably stylistically horrible and likely substantially so. Feel free to ignore, just an experiment.