### PR TITLE
Use Charlock Holmes for encoding detection/conversion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,13 +5,14 @@ AllCops:
     - test/fixtures/**/*
     - test/functions.rb
 
-Style/AlignHash:
+Layout/AlignHash:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
 
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+    - licensee.gemspec
 
 Style/Documentation:
   Enabled: false
@@ -29,5 +30,5 @@ Metrics/ClassLength:
 Metrics/AbcSize:
   Enabled: false
 
-Style/IndentHeredoc:
+Layout/IndentHeredoc:
   Enabled: false

--- a/lib/licensee/project_file.rb
+++ b/lib/licensee/project_file.rb
@@ -1,18 +1,18 @@
+require 'charlock_holmes'
+
 module Licensee
   class Project
     class File
       attr_reader :content, :filename
 
-      ENCODING = Encoding::UTF_8
-      ENCODING_OPTIONS = {
-        invalid: :replace,
-        undef:   :replace,
-        replace: ''
-      }.freeze
-
       def initialize(content, filename = nil)
         @content = content
-        @content.encode!(ENCODING, ENCODING_OPTIONS)
+        unless @content.empty?
+          detection = CharlockHolmes::EncodingDetector.detect(content)
+          @content = CharlockHolmes::Converter.convert @content,
+                                                       detection[:encoding],
+                                                       'UTF-8'
+        end
         @filename = filename
       end
 

--- a/licensee.gemspec
+++ b/licensee.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.executables << 'licensee'
 
   gem.add_dependency('rugged', '~> 0.24')
+  gem.add_dependency('charlock_holmes', '~> 0.7')
   gem.add_development_dependency('pry', '~> 0.9')
   gem.add_development_dependency('rspec', '~> 3.5')
   gem.add_development_dependency('rake', '~> 10.3')

--- a/spec/fixtures/copyright-encoding/COPYING
+++ b/spec/fixtures/copyright-encoding/COPYING
@@ -1,0 +1,1 @@
+Copyright © 2013–2016 by Peder Ås, 王二麻子, and Seán Ó Rudaí

--- a/spec/licensee/project_spec.rb
+++ b/spec/licensee/project_spec.rb
@@ -58,6 +58,16 @@
       end
     end
 
+    context 'encoding correctness' do
+      let(:fixture) { 'copyright-encoding' }
+
+      it "returns a file's content" do
+        expect(subject.license_file.content).to match(
+          'Copyright © 2013–2016 by Peder Ås, 王二麻子, and Seán Ó Rudaí'
+        )
+      end
+    end
+
     context 'readme detection' do
       let(:fixture) { 'readme' }
       subject { described_class.new(path, detect_readme: true) }


### PR DESCRIPTION
Fixes #79 

Introduces a new dependency, found at https://github.com/libgit2/rugged/issues/588#issuecomment-202773337 which is probably [a pain install on Windows](https://github.com/brianmario/charlock_holmes/issues/84#issuecomment-140239662).

I have no opinion on whether worth trouble.