### PR TITLE
Return the "other" license when a license is found but cannot be identified

### DIFF
--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -4,7 +4,8 @@ require 'yaml'
 module Licensee
   class InvalidLicense < ArgumentError; end
   class License
-    @all ||= {}
+    @all = {}
+    @keys_licenses = {}
 
     class << self
       # All license objects defined via Licensee (via choosealicense.com)
@@ -32,7 +33,7 @@ module Licensee
 
       def find(key, options = {})
         options = { hidden: true }.merge(options)
-        all(options).find { |license| key.casecmp(license.key).zero? }
+        keys_licenses(options)[key.downcase]
       end
       alias [] find
       alias find_by_key find
@@ -50,6 +51,10 @@ module Licensee
 
       def licenses
         @licenses ||= keys.map { |key| new(key) }
+      end
+
+      def keys_licenses(options = {})
+        @keys_licenses[options] ||= all(options).map { |l| [l.key, l] }.to_h
       end
     end
 

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -4,6 +4,8 @@ require 'yaml'
 module Licensee
   class InvalidLicense < ArgumentError; end
   class License
+    @all ||= {}
+
     class << self
       # All license objects defined via Licensee (via choosealicense.com)
       #
@@ -13,11 +15,13 @@ module Licensee
       #
       # Returns an Array of License objects.
       def all(options = {})
-        options = { hidden: false, featured: nil }.merge(options)
-        output = licenses.dup
-        output.reject!(&:hidden?) unless options[:hidden]
-        return output if options[:featured].nil?
-        output.select { |l| l.featured? == options[:featured] }
+        @all[options] ||= begin
+          options = { hidden: false, featured: nil }.merge(options)
+          output = licenses.dup
+          output.reject!(&:hidden?) unless options[:hidden]
+          return output if options[:featured].nil?
+          output.select { |l| l.featured? == options[:featured] }
+        end
       end
 
       def keys

--- a/lib/licensee/matchers/exact_matcher.rb
+++ b/lib/licensee/matchers/exact_matcher.rb
@@ -8,7 +8,8 @@ module Licensee
       end
 
       def match
-        Licensee.licenses(hidden: true).find do |license|
+        return @match if defined? @match
+        @match = Licensee.licenses(hidden: true).find do |license|
           license.length == @file.length && license.wordset == @file.wordset
         end
       end

--- a/lib/licensee/matchers/package_matcher.rb
+++ b/lib/licensee/matchers/package_matcher.rb
@@ -6,7 +6,12 @@ module Licensee
       end
 
       def match
-        Licensee.licenses(hidden: true).find { |l| l.key == license_property }
+        return @match if defined? @match
+        return if license_property.nil? || license_property.to_s.empty?
+        @match = Licensee.licenses(hidden: true).find do |license|
+          license.key == license_property
+        end
+        @match ||= License.find('other')
       end
 
       def confidence

--- a/lib/licensee/project.rb
+++ b/lib/licensee/project.rb
@@ -14,7 +14,11 @@ module Licensee
     # Returns the matching License instance if a license can be detected
     def license
       return @license if defined? @license
-      @license = (licenses.first if licenses.count == 1 || lgpl?)
+      @license = if licenses.count == 1 || lgpl?
+        licenses.first
+      elsif licenses.count > 1
+        License.find('other')
+      end
     end
 
     # Returns an array of detected Licenses

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -68,6 +68,14 @@ module Licensee
         license && license.gpl?
       end
 
+      def license
+        if matcher && matcher.match
+          matcher.match
+        else
+          License.find('other')
+        end
+      end
+
       def self.name_score(filename)
         FILENAME_REGEXES.find { |regex, _| filename =~ regex }[1]
       end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -30,16 +30,16 @@ RSpec.describe 'integration test' do
 
         context 'with no license files' do
           let(:project_path) { Dir.mktmpdir }
-          let(:file_path) { File.expand_path("foo.md", project_path) }
+          let(:file_path) { File.expand_path('foo.md', project_path) }
 
           before do
-            File.write(file_path, "bar")
+            File.write(file_path, 'bar')
             git_init(project_path) if project_type == Licensee::GitProject
           end
 
           after { FileUtils.rm_rf(project_path) }
 
-          it "returns nil" do
+          it 'returns nil' do
             expect(subject.license).to be_nil
             expect(subject.license_files).to be_empty
 

--- a/spec/licensee/matchers/cran_matcher_spec.rb
+++ b/spec/licensee/matchers/cran_matcher_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Licensee::Matchers::Cran do
     'GPL (>=3)'                => Licensee::License.find('gpl-3.0'),
     'GPL-2'                    => Licensee::License.find('gpl-2.0'),
     'GPL-3'                    => Licensee::License.find('gpl-3.0'),
-    'Foo'                      => Licensee::License.find('other'),
+    'Foo'                      => Licensee::License.find('other')
   }.each do |license_declaration, license|
     context "with '#{license_declaration}' declaration" do
       let(:content) { "Package: test\nLicense: #{license_declaration}" }
@@ -38,10 +38,10 @@ RSpec.describe Licensee::Matchers::Cran do
     end
   end
 
-  context "with no license field" do
-    let(:content) { "Package: test" }
+  context 'with no license field' do
+    let(:content) { 'Package: test' }
 
-    it "returns nil" do
+    it 'returns nil' do
       expect(subject.match).to be_nil
     end
   end

--- a/spec/licensee/matchers/cran_matcher_spec.rb
+++ b/spec/licensee/matchers/cran_matcher_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Licensee::Matchers::Cran do
     'GPL (>=2) + file LICENSE' => Licensee::License.find('gpl-2.0'),
     'GPL (>=3)'                => Licensee::License.find('gpl-3.0'),
     'GPL-2'                    => Licensee::License.find('gpl-2.0'),
-    'GPL-3'                    => Licensee::License.find('gpl-3.0')
+    'GPL-3'                    => Licensee::License.find('gpl-3.0'),
+    'Foo'                      => Licensee::License.find('other'),
   }.each do |license_declaration, license|
     context "with '#{license_declaration}' declaration" do
       let(:content) { "Package: test\nLicense: #{license_declaration}" }
@@ -34,6 +35,14 @@ RSpec.describe Licensee::Matchers::Cran do
       it 'matches' do
         expect(subject.match).to eql(license)
       end
+    end
+  end
+
+  context "with no license field" do
+    let(:content) { "Package: test" }
+
+    it "returns nil" do
+      expect(subject.match).to be_nil
     end
   end
 end

--- a/spec/licensee/matchers/dice_matcher_spec.rb
+++ b/spec/licensee/matchers/dice_matcher_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe Licensee::Matchers::Dice do
     end
 
     it "doesn't match" do
-      skip 'Stacked MIT + GPL not properly detected'
       expect(content).to_not be_detected_as(gpl)
       expect(subject.match).to eql(nil)
       expect(subject.matches).to be_empty

--- a/spec/licensee/matchers/dist_zilla_matcher_spec.rb
+++ b/spec/licensee/matchers/dist_zilla_matcher_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Licensee::Matchers::DistZilla do
 
   {
     'spdx name'     => ['license = MIT', 'mit'],
-    'non spdx name' => ['license = Mozilla_2_0', 'mpl-2.0']
+    'non spdx name' => ['license = Mozilla_2_0', 'mpl-2.0'],
+    'other license' => ['license = Foo', 'other']
   }.each do |description, license_declaration_and_key|
     context "with a #{description}" do
       let(:content) { license_declaration_and_key[0] }
@@ -27,6 +28,14 @@ RSpec.describe Licensee::Matchers::DistZilla do
       it 'matches' do
         expect(subject.match).to eql(license)
       end
+    end
+  end
+
+  context "no license field" do
+    let(:content) { "foo = bar" }
+
+    it "returns nil" do
+      expect(subject.match).to be_nil
     end
   end
 end

--- a/spec/licensee/matchers/dist_zilla_matcher_spec.rb
+++ b/spec/licensee/matchers/dist_zilla_matcher_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe Licensee::Matchers::DistZilla do
     end
   end
 
-  context "no license field" do
-    let(:content) { "foo = bar" }
+  context 'no license field' do
+    let(:content) { 'foo = bar' }
 
-    it "returns nil" do
+    it 'returns nil' do
       expect(subject.match).to be_nil
     end
   end

--- a/spec/licensee/matchers/gemspec_matcher_spec.rb
+++ b/spec/licensee/matchers/gemspec_matcher_spec.rb
@@ -27,18 +27,18 @@ RSpec.describe Licensee::Matchers::Gemspec do
     end
   end
 
-  context "no license field" do
+  context 'no license field' do
     let(:content) { "s.foo = 'bar'" }
 
-    it "returns nil" do
+    it 'returns nil' do
       expect(subject.match).to be_nil
     end
   end
 
-  context "an unknown license" do
+  context 'an unknown license' do
     let(:content) { "s.license = 'foo'" }
 
-    it "returns other" do
+    it 'returns other' do
       expect(subject.match).to eql(Licensee::License.find('other'))
     end
   end

--- a/spec/licensee/matchers/gemspec_matcher_spec.rb
+++ b/spec/licensee/matchers/gemspec_matcher_spec.rb
@@ -26,4 +26,20 @@ RSpec.describe Licensee::Matchers::Gemspec do
       end
     end
   end
+
+  context "no license field" do
+    let(:content) { "s.foo = 'bar'" }
+
+    it "returns nil" do
+      expect(subject.match).to be_nil
+    end
+  end
+
+  context "an unknown license" do
+    let(:content) { "s.license = 'foo'" }
+
+    it "returns other" do
+      expect(subject.match).to eql(Licensee::License.find('other'))
+    end
+  end
 end

--- a/spec/licensee/matchers/npm_bower_matcher_spec.rb
+++ b/spec/licensee/matchers/npm_bower_matcher_spec.rb
@@ -29,18 +29,18 @@ RSpec.describe Licensee::Matchers::NpmBower do
     end
   end
 
-  context "no license field" do
-    let(:content) { "foo: bar" }
+  context 'no license field' do
+    let(:content) { 'foo: bar' }
 
-    it "returns nil" do
+    it 'returns nil' do
       expect(subject.match).to be_nil
     end
   end
 
-  context "an unknown license" do
+  context 'an unknown license' do
     let(:content) { "'license': 'foo'" }
 
-    it "returns other" do
+    it 'returns other' do
       expect(subject.match).to eql(Licensee::License.find('other'))
     end
   end

--- a/spec/licensee/matchers/npm_bower_matcher_spec.rb
+++ b/spec/licensee/matchers/npm_bower_matcher_spec.rb
@@ -28,4 +28,20 @@ RSpec.describe Licensee::Matchers::NpmBower do
       end
     end
   end
+
+  context "no license field" do
+    let(:content) { "foo: bar" }
+
+    it "returns nil" do
+      expect(subject.match).to be_nil
+    end
+  end
+
+  context "an unknown license" do
+    let(:content) { "'license': 'foo'" }
+
+    it "returns other" do
+      expect(subject.match).to eql(Licensee::License.find('other'))
+    end
+  end
 end

--- a/spec/licensee/matchers/package_matcher_spec.rb
+++ b/spec/licensee/matchers/package_matcher_spec.rb
@@ -2,8 +2,11 @@ RSpec.describe Licensee::Matchers::Package do
   let(:mit) { Licensee::License.find('mit') }
   let(:content) { '' }
   let(:file) { Licensee::Project::LicenseFile.new(content, 'project.gemspec') }
+  let(:license_property) { 'mit' }
   subject { described_class.new(file) }
-  before { allow(subject).to receive(:license_property).and_return('mit') }
+  before do
+    allow(subject).to receive(:license_property).and_return(license_property)
+  end
 
   it 'matches' do
     expect(subject.match).to eql(mit)
@@ -11,5 +14,29 @@ RSpec.describe Licensee::Matchers::Package do
 
   it 'has confidence' do
     expect(subject.confidence).to eql(90)
+  end
+
+  context "with a nil license property" do
+    let(:license_property) { nil }
+
+    it "matches to nil" do
+      expect(subject.match).to be_nil
+    end
+  end
+
+  context "with an empty license property" do
+    let(:license_property) { "" }
+
+    it "matches to nil" do
+      expect(subject.match).to be_nil
+    end
+  end
+
+  context "with an unmatched license proprerty" do
+    let(:license_property) { "foo" }
+
+    it "matches to other" do
+      expect(subject.match).to eql(Licensee::License.find('other'))
+    end
   end
 end

--- a/spec/licensee/matchers/package_matcher_spec.rb
+++ b/spec/licensee/matchers/package_matcher_spec.rb
@@ -16,26 +16,26 @@ RSpec.describe Licensee::Matchers::Package do
     expect(subject.confidence).to eql(90)
   end
 
-  context "with a nil license property" do
+  context 'with a nil license property' do
     let(:license_property) { nil }
 
-    it "matches to nil" do
+    it 'matches to nil' do
       expect(subject.match).to be_nil
     end
   end
 
-  context "with an empty license property" do
-    let(:license_property) { "" }
+  context 'with an empty license property' do
+    let(:license_property) { '' }
 
-    it "matches to nil" do
+    it 'matches to nil' do
       expect(subject.match).to be_nil
     end
   end
 
-  context "with an unmatched license proprerty" do
-    let(:license_property) { "foo" }
+  context 'with an unmatched license proprerty' do
+    let(:license_property) { 'foo' }
 
-    it "matches to other" do
+    it 'matches to other' do
       expect(subject.match).to eql(Licensee::License.find('other'))
     end
   end

--- a/spec/licensee/project_files/license_file_spec.rb
+++ b/spec/licensee/project_files/license_file_spec.rb
@@ -230,11 +230,11 @@ Creative Commons Attribution-NonCommercial 4.0
     end
   end
 
-  context "an unknown license" do
+  context 'an unknown license' do
     let(:content) { 'foo' }
     let(:other) { Licensee::License.find('other') }
 
-    it "matches to other" do
+    it 'matches to other' do
       expect(subject.license).to eql(other)
     end
   end

--- a/spec/licensee/project_files/license_file_spec.rb
+++ b/spec/licensee/project_files/license_file_spec.rb
@@ -229,4 +229,13 @@ Creative Commons Attribution-NonCommercial 4.0
       end
     end
   end
+
+  context "an unknown license" do
+    let(:content) { 'foo' }
+    let(:other) { Licensee::License.find('other') }
+
+    it "matches to other" do
+      expect(subject.license).to eql(other)
+    end
+  end
 end

--- a/spec/licensee/project_spec.rb
+++ b/spec/licensee/project_spec.rb
@@ -1,6 +1,7 @@
 [Licensee::FSProject, Licensee::GitProject].each do |project_type|
   RSpec.describe project_type do
     let(:mit) { Licensee::License.find('mit') }
+    let(:other) { Licensee::License.find('other') }
     let(:fixture) { 'mit' }
     let(:path) { fixture_path(fixture) }
     subject { described_class.new(path) }
@@ -117,8 +118,8 @@
     context 'multiple licenses' do
       let(:fixture) { 'multiple-license-files' }
 
-      it 'returns nil for license' do
-        expect(subject.license).to be_nil
+      it 'returns other for license' do
+        expect(subject.license).to eql(other)
       end
 
       it 'returns nil for matched_file' do

--- a/spec/vendored_license_spec.rb
+++ b/spec/vendored_license_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe 'vendored licenes' do
           let(:content) { wtfpl.send :strip_title, content_with_copyright }
 
           it 'detects the license' do
-            skip 'The WTFPL is too short to be modified' if license == wtfpl
             expect(content).to be_detected_as(license)
           end
         end


### PR DESCRIPTION
An alternative to https://github.com/benbalter/licensee/pull/190, taking into account to the multiple license support provided in https://github.com/benbalter/licensee/pull/203, and per @mlinksva's comments over in https://github.com/benbalter/licensee/pull/203#issuecomment-310448532, this PR changes Licensee's behavior, such that if we detect the author suspected to license their project, but are unable to identify the license, we return the "other" pseudo license, rather than `nil`, with `nil` responses indicating that no intent to license was detected.

A few examples of what `Project#license` would return:

* `LICENSE` file with an unknown license - "other" license
* Project with no license file - `nil`
* Project with multiple identified licenses - "other" license (`licenses` would return an array of licenses)
* Project in which the `LICENSE` file and package manager license conflict - - "other" license (`licenses` would return an array of licenses)
* Project with a package file (e.g. Gemspec) with no license property - `nil`
* Project with a package file (.e.g, Gemspec) with an unknown license value - "other" license

Thoughts on this behavior? This would be a breaking change and require a major version bump.

In either event, thanks for spiking out the early work in #190 and for pushing the conversation.