### PR TITLE
Cabal project file matcher

### DIFF
--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -23,6 +23,7 @@ require_relative 'licensee/matchers/gemspec_matcher'
 require_relative 'licensee/matchers/npm_bower_matcher'
 require_relative 'licensee/matchers/cran_matcher'
 require_relative 'licensee/matchers/dist_zilla_matcher'
+require_relative 'licensee/matchers/cabal_matcher'
 
 module Licensee
   # Over which percent is a match considered a match by default

--- a/lib/licensee/matchers/cabal_matcher.rb
+++ b/lib/licensee/matchers/cabal_matcher.rb
@@ -1,0 +1,16 @@
+module Licensee
+  module Matchers
+    class Cabal < Package
+      # While we could parse the cabal file, prefer
+      # a lenient regex for speed and security. Moar parsing moar problems.
+      LICENSE_REGEX = /^\s*license\s*\:\s*([a-z\-0-9\.]+)\s*$/ix
+
+      private
+
+      def license_property
+        match = @file.content.match LICENSE_REGEX
+        match[1].downcase if match && match[1]
+      end
+    end
+  end
+end

--- a/lib/licensee/matchers/npm_bower_matcher.rb
+++ b/lib/licensee/matchers/npm_bower_matcher.rb
@@ -4,7 +4,7 @@ module Licensee
       # While we could parse the package.json or bower.json file, prefer
       # a lenient regex for speed and security. Moar parsing moar problems.
       LICENSE_REGEX = /
-        s*[\"\']license[\"\']\s*\:\s*[\'\"]([a-z\-0-9\.]+)[\'\"],?\s*
+        \s*[\"\']license[\"\']\s*\:\s*[\'\"]([a-z\-0-9\.]+)[\'\"],?\s*
       /ix
 
       private

--- a/lib/licensee/project_files/package_info.rb
+++ b/lib/licensee/project_files/package_info.rb
@@ -7,6 +7,8 @@ module Licensee
           [Matchers::Gemspec]
         when '.json'
           [Matchers::NpmBower]
+        when '.cabal'
+          [Matchers::Cabal]
         else
           if filename == 'DESCRIPTION' && content.match(/^Package:/)
             [Matchers::Cran]
@@ -19,7 +21,7 @@ module Licensee
       end
 
       def self.name_score(filename)
-        return 1.0  if ::File.extname(filename) == '.gemspec'
+        return 1.0  if ['.gemspec', '.cabal'].include?(::File.extname(filename))
         return 1.0  if filename == 'package.json'
         return 0.8  if filename == 'dist.ini'
         return 0.9  if filename == 'DESCRIPTION'

--- a/spec/licensee/matchers/cabal_matcher_spec.rb
+++ b/spec/licensee/matchers/cabal_matcher_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Licensee::Matchers::Cabal do
+  let(:content) { 'license: mit' }
+  let(:file) { Licensee::Project::LicenseFile.new(content, 'LICENSE.txt') }
+  let(:mit) { Licensee::License.find('mit') }
+  let(:no_license) { Licensee::License.find('no-license') }
+  subject { described_class.new(file) }
+
+  it 'matches' do
+    expect(subject.match).to eql(mit)
+  end
+
+  it 'has a confidence' do
+    expect(subject.confidence).to eql(90)
+  end
+
+  {
+    'whitespace'         => 'license : mit',
+    'no whitespace'      => 'license:mit',
+    'leading whitespace' => ' license:mit'
+  }.each do |description, license_declaration|
+    context "with a #{description} declaration" do
+      let(:content) { license_declaration }
+
+      it 'matches' do
+        expect(subject.match).to eql(mit)
+      end
+    end
+  end
+
+  context 'no license field' do
+    let(:content) { 'foo: bar' }
+
+    it 'returns nil' do
+      expect(subject.match).to be_nil
+    end
+  end
+
+  context 'an unknown license' do
+    let(:content) { 'license: foo' }
+
+    it 'returns other' do
+      expect(subject.match).to eql(Licensee::License.find('other'))
+    end
+  end
+end

--- a/spec/licensee/matchers/npm_bower_matcher_spec.rb
+++ b/spec/licensee/matchers/npm_bower_matcher_spec.rb
@@ -14,11 +14,12 @@ RSpec.describe Licensee::Matchers::NpmBower do
   end
 
   {
-    'double quotes' => '"license": "mit"',
-    'single quotes' => "'license': 'mit'",
-    'mixed quotes'  => "'license': \"mit\"",
-    'whitespace'    => "'license' : 'mit'",
-    'no whitespace' => "'license':'mit'"
+    'double quotes'      => '"license": "mit"',
+    'single quotes'      => "'license': 'mit'",
+    'mixed quotes'       => "'license': \"mit\"",
+    'whitespace'         => "'license' : 'mit'",
+    'no whitespace'      => "'license':'mit'",
+    'leading whitespace' => " 'license':'mit'"
   }.each do |description, license_declaration|
     context "with a #{description} declaration" do
       let(:content) { license_declaration }

--- a/spec/licensee/project_files/package_info_spec.rb
+++ b/spec/licensee/project_files/package_info_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Licensee::Project::PackageInfo do
   context 'name scoring' do
     {
       'licensee.gemspec' => 1.0,
+      'test.cabal'       => 1.0,
       'package.json'     => 1.0,
       'DESCRIPTION'      => 0.9,
       'dist.ini'         => 0.8,
@@ -29,6 +30,14 @@ RSpec.describe Licensee::Project::PackageInfo do
 
       it 'returns the gemspec matcher' do
         expect(possible_matchers).to eql([Licensee::Matchers::Gemspec])
+      end
+    end
+
+    context 'with cabal file ' do
+      let(:filename) { 'test.cabal' }
+
+      it 'returns the cabal matcher' do
+        expect(possible_matchers).to eql([Licensee::Matchers::Cabal])
       end
     end
 


### PR DESCRIPTION
Adds matching for Haskells cabal files which are yaml.

**NOTE:** Also fixed a small issue with the npm/bower matcher regex.