### PR TITLE
Add script/diff 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ Layout/AlignHash:
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+    - licensee.gemspec
 
 Style/Documentation:
   Enabled: false

--- a/bin/licensee
+++ b/bin/licensee
@@ -4,10 +4,6 @@ require_relative '../lib/licensee'
 
 path = ARGV[0] || Dir.pwd
 
-def format_percent(float)
-  "#{format('%.2f', float)}%"
-end
-
 # Given a string or object, prepares it for output and human consumption
 def humanize(value, type = nil)
   case type
@@ -16,7 +12,7 @@ def humanize(value, type = nil)
   when :matcher
     value.class
   when :confidence
-    format_percent(value)
+    Licensee::ContentHelper.format_percent(value)
   when :method
     value.to_s.tr('_', ' ').capitalize
   else
@@ -60,7 +56,8 @@ project.matched_files.each do |matched_file|
   puts '  Closest licenses:'
   licenses[0...3].each do |license, similarity|
     spdx_id = license.meta['spdx-id']
-    puts "    * #{spdx_id} similarity: #{format_percent(similarity)}"
+    percent = Licensee::ContentHelper.format_percent(similarity)
+    puts "    * #{spdx_id} similarity: #{percent}"
   end
 end
 

--- a/script/diff
+++ b/script/diff
@@ -15,7 +15,8 @@ license = Licensee::License.find(ARGV[0])
 
 if license.nil?
   puts "#{ARGV[0]} is not a valid license"
-  puts "Valid licenses: #{Licensee::License.all(hidden: true).map(&:key).join(', ')}"
+  licenses = Licensee::License.all(hidden: true).map(&:key).join(', ')
+  puts "Valid licenses: #{licenses}"
   exit 1
 end
 
@@ -31,12 +32,12 @@ similarity = Licensee::ContentHelper.format_percent(similarity)
 puts "  Similarity: #{similarity}"
 
 if left == right
-  puts "  Exact match!"
+  puts '  Exact match!'
   exit
 end
 
 dir = Dir.mktmpdir
-path = File.expand_path "LICENSE", dir
+path = File.expand_path 'LICENSE', dir
 
 Dir.chdir(dir) do
   `git init`

--- a/script/diff
+++ b/script/diff
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+# Diffs STDIN against a known license
+# Example usage: cat LICENSE.md | be script/diff mit
+
+require 'licensee'
+
+if STDIN.tty? || ARGV[0].to_s.empty?
+  puts 'USAGE: [LICENSE_CONTENT] | script/diff [LICENSE_ID]'
+  exit 1
+end
+
+text = STDIN.read
+license_file = Licensee::Project::LicenseFile.new(text, 'LICENSE')
+license = Licensee::License.find(ARGV[0])
+
+if license.nil?
+  puts "#{ARGV[0]} is not a valid license"
+  puts "Valid licenses: #{Licensee::License.all(hidden: true).map(&:key).join(', ')}"
+  exit 1
+end
+
+puts "Comparing to #{license.name}:"
+
+left = license.content_normalized(wrap: 80)
+right = license_file.content_normalized(wrap: 80)
+
+puts "  Input length: #{license_file.length}"
+puts "  License length: #{license.length}"
+similarity = license.similarity(license_file)
+similarity = Licensee::ContentHelper.format_percent(similarity)
+puts "  Similarity: #{similarity}"
+
+if left == right
+  puts "  Exact match!"
+  exit
+end
+
+dir = Dir.mktmpdir
+path = File.expand_path "LICENSE", dir
+
+Dir.chdir(dir) do
+  `git init`
+  File.write(path, left)
+  `git add LICENSE`
+  `git commit -m 'left'`
+  File.write(path, right)
+  puts `git diff --word-diff`
+end

--- a/script/git-repo
+++ b/script/git-repo
@@ -1,11 +1,19 @@
 #!/bin/sh
 # Runs the licensee command against a remote git repo
 
+set -e
+
 repo=$1
 name=$(basename $repo)
 dir="./tmp/$name"
+rm -Rf "$dir"
 
 git clone --depth 1 --quiet "$repo" "$dir"
 bundle exec bin/licensee "$dir"
+
+if [ "$2" = "--license" ]; then
+  license_path=$(bundle exec ./script/license-path $dir)
+  cat $license_path | bundle exec script/diff $3
+fi
 
 rm -Rf "$dir"

--- a/script/license-path
+++ b/script/license-path
@@ -4,7 +4,7 @@
 require 'licensee'
 
 if ARGV[0].to_s.empty?
-  "Usage: script/license-path [PROJECT_PATH]"
+  puts 'Usage: script/license-path [PROJECT_PATH]'
   exit 1
 end
 

--- a/script/license-path
+++ b/script/license-path
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# Given a project, returns the path to its license
+
+require 'licensee'
+
+if ARGV[0].to_s.empty?
+  "Usage: script/license-path [PROJECT_PATH]"
+  exit 1
+end
+
+project = Licensee.project(ARGV[0])
+
+if project.license_file
+  puts File.expand_path project.license_file.path, ARGV[0]
+else
+  exit 1
+end

--- a/spec/licensee/content_helper_spec.rb
+++ b/spec/licensee/content_helper_spec.rb
@@ -76,6 +76,16 @@ EOS
       expect(normalized_content).to_not include '* *'
     end
 
+    it 'strips formatting from the MPL' do
+      license = Licensee::License.find('mpl-2.0')
+      expect(license.content_normalized).to_not include('* *')
+    end
+
+    it 'wraps' do
+      lines = mit.content_normalized(wrap: 40).split("\n")
+      expect(lines.first.length).to be <= 40
+    end
+
     it 'squeezes whitespace' do
       expect(normalized_content).to_not match '  '
     end

--- a/spec/licensee/content_helper_spec.rb
+++ b/spec/licensee/content_helper_spec.rb
@@ -56,6 +56,17 @@ EOS
     expect(subject.content_hash).to eql(content_hash)
   end
 
+  it 'wraps' do
+    content = Licensee::ContentHelper.wrap(mit.content, 40)
+    lines = content.split("\n")
+    expect(lines.first.length).to be <= 40
+  end
+
+  it 'formats percents' do
+    percent = Licensee::ContentHelper.format_percent(12.3456789)
+    expect(percent).to eql('12.35%')
+  end
+
   context 'normalizing' do
     let(:normalized_content) { subject.content_normalized }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,22 +36,6 @@ def sub_copyright_info(text)
   text
 end
 
-def wrap(text, line_width = 80)
-  return if text.nil?
-  text = text.clone
-  text.gsub!(/([^\n])\n([^\n])/, '\1 \2')
-
-  text = text.split("\n").collect do |line|
-    if line.length > line_width
-      line.gsub(/(.{1,#{line_width}})(\s+|$)/, "\\1\n").strip
-    else
-      line
-    end
-  end * "\n"
-
-  text.strip
-end
-
 # Add random words to the end of a license to test similarity tollerances
 def add_random_words(string, count = 5)
   words = string.dup.split(' ')
@@ -88,9 +72,9 @@ end
 
 RSpec::Matchers.define :be_detected_as do |expected|
   match do |actual|
-    @expected_as_array = [wrap(expected.content_normalized)]
+    @expected_as_array = [expected.content_normalized(wrap: 80)]
     license_file = Licensee::Project::LicenseFile.new(actual, 'LICENSE')
-    @actual = wrap(license_file.content_normalized)
+    @actual = license_file.content_normalized(wrap: 80)
     return false unless license_file.license
     values_match? expected, license_file.license
   end

--- a/spec/vendored_license_spec.rb
+++ b/spec/vendored_license_spec.rb
@@ -17,8 +17,10 @@ RSpec.describe 'vendored licenses' do
 
       context 'when modified' do
         let(:line_length) { 60 }
-        let(:random_words) { 50 }
-        let(:content_rewrapped) { wrap(content_with_copyright, line_length) }
+        let(:random_words) { 75 }
+        let(:content_rewrapped) do
+          Licensee::ContentHelper.wrap(content_with_copyright, line_length)
+        end
         let(:content_with_random_words) do
           add_random_words(content_with_copyright, random_words)
         end
@@ -58,7 +60,9 @@ RSpec.describe 'vendored licenses' do
         end
 
         context 'when rewrapped with random words added' do
-          let(:content) { wrap(content_with_random_words, line_length) }
+          let(:content) do
+            Licensee::ContentHelper.wrap(content_with_random_words, line_length)
+          end
 
           it 'does not match the license' do
             expect(content).to_not be_detected_as(license)


### PR DESCRIPTION
Debugging https://github.com/benbalter/licensee/issues/211#issue-239788329 made me wish I had a script to normalize and diff a known license against a repo's license, so I made just that.

Usage 1 (diff license text versus known license):

```
$ cat LICENSE.txt | bundle exec script/diff mit
```

Usage 2 (diff git repo versus known license):

```
script/git-repo https://github.com/benbalter/licensee --license mit
```

Example outputs:

```
➜  licensee git:(diff-script) script/git-repo https://github.com/deepak/blog-playground --license isc
License: Other
Matched files: ["LICENSE"]
LICENSE:
  Content hash: 7e0cbf4105921845c0f33af9b6a34f8f5eac7c6e
  Attribution: Copyright (c) 2016, Deepak Kannan
  License: Other
Comparing to ISC License:
  Input length: 485
  License length: 695
  Similarity: 87.18%

diff --git a/LICENSE b/LICENSE
index b11509f..1d009ed 100644
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,7 @@
[-permission to use, copy, modify, and/or distribute this software for any purpose-]
[-with or without fee is hereby granted, provided that the above copyright notice-]
[-and this permission notice appear in all copies.-]the software is provided "as is" and the author disclaims all warranties with
regard to this software including all implied warranties of merchantability and
fitness. in no event shall the author be liable for any special, direct,
indirect, or consequential damages or any damages whatsoever resulting from loss
of use, data or profits, whether in an action of contract, negligence or other
tortious action, arising out of or in connection with the use or performance of
this software.
```

```
➜  licensee git:(diff-script) script/git-repo https://github.com/j256/simplejmx --license isc
License: Other
Matched files: ["LICENSE.txt"]
LICENSE.txt:
  Content hash: f6b006d308a7b1608adb4fe194d3ea812e3b18db
  License: Other
  Closest licenses:
    * ISC similarity: 94.81%
Comparing to ISC License:
  Input length: 700
  License length: 695
  Similarity: 94.81%

diff --git a/LICENSE b/LICENSE
index b11509f..1d7af61 100644
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,9 @@
permission to use, copy, modify, and/or distribute this software for any purpose
with or without fee is hereby granted, provided that[-the above copyright notice-]
[-and-] this permission notice
appear in all copies. the software is provided "as is" and the author disclaims
all warranties with regard to this software including all implied warranties of
merchantability and fitness. in no event shall the author be liable for any
special, direct, indirect, or consequential damages or any damages whatsoever
resulting from loss of use, data or profits, whether in an action of contract,
negligence or other tortious action, arising out of or in connection with the
use or performance of this software. {+https://opensource.org/licenses/isc+}
```

This script is only available when the repo is cloned locally.

/cc @mlinksva FYI