### PR TITLE
Adding license_dirs function allowing you to add other license locations

### DIFF
--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -8,6 +8,18 @@ module Licensee
     @keys_licenses = {}
 
     class << self
+      def default_license_dir
+        dir = ::File.dirname(__FILE__)
+        ::File.expand_path '../../vendor/choosealicense.com/_licenses', dir
+      end
+
+      # Backwards compatability
+      alias license_dir default_license_dir
+    end
+
+    @license_dirs = [ default_license_dir() ]
+
+    class << self
       # All license objects defined via Licensee (via choosealicense.com)
       #
       # Options:
@@ -38,13 +50,23 @@ module Licensee
       alias [] find
       alias find_by_key find
 
-      def license_dir
-        dir = ::File.dirname(__FILE__)
-        ::File.expand_path '../../vendor/choosealicense.com/_licenses', dir
+      def license_dirs
+        return @license_dirs
       end
 
+      # A user customized lookup array of directories for license files. If the user wants 
+      # to include the default, they should make one of the entries be default_license_dir()
+      def license_dirs=(dirs)
+        @license_dirs=dirs
+      end
+
+      # Returns all the license files across the various license directories
       def license_files
-        @license_files ||= Dir.glob("#{license_dir}/*.txt")
+        files=[]
+        @license_dirs.each do |dir|
+          files.concat(Dir.glob("#{dir}/*.txt"))
+        end
+        @license_files ||= files
       end
 
       private
@@ -82,7 +104,14 @@ module Licensee
 
     # Path to vendored license file on disk
     def path
-      @path ||= File.expand_path "#{@key}.txt", Licensee::License.license_dir
+      foundpath=nil
+      Licensee::License.license_dirs().each do |dir|
+        foundpath = File.expand_path "#{@key}.txt", dir
+        if(File.exist?(foundpath))
+          break
+        end
+      end
+      @path = foundpath
     end
 
     # License metadata from YAML front matter with defaults merged in


### PR DESCRIPTION
First attempt at issue #196 

Let me know what you think. 

  Licensee::License.license_dirs=[my_special_dir, Licensee::License.default_license_dir]
  project=Licensee::Projects::GitProject.new(review_directory)

It's only useful at the code level right now. Next step would be to add an environment variable or command line argument. 