### PR TITLE
Convert License#meta to a Struct

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,6 @@ Metrics/AbcSize:
 
 Layout/IndentHeredoc:
   Enabled: false
+  
+Style/StructInheritance:
+  Enabled: false

--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -6,6 +6,7 @@ require 'rugged'
 module Licensee
   autoload :ContentHelper, 'licensee/content_helper'
   autoload :License, 'licensee/license'
+  autoload :LicenseMeta, 'licensee/license_meta'
   autoload :Rule, 'licensee/rule'
   autoload :Matchers, 'licensee/matchers'
   autoload :Projects, 'licensee/projects'

--- a/lib/licensee/license_meta.rb
+++ b/lib/licensee/license_meta.rb
@@ -39,7 +39,7 @@ module Licensee
 
       # Array of symbolized helper methods to expose on the License class
       def helper_methods
-        members + PREDICATE_FIELDS.map { |f| "#{f}?".to_sym }
+        members - PREDICATE_FIELDS + PREDICATE_FIELDS.map { |f| "#{f}?".to_sym }
       end
     end
 

--- a/lib/licensee/license_meta.rb
+++ b/lib/licensee/license_meta.rb
@@ -1,0 +1,50 @@
+require 'yaml'
+
+module Licensee
+  class LicenseMeta < Struct.new(
+    :title, :spdx_id, :source, :description, :how, :conditions, :permissions,
+    :limitations, :using, :featured, :hidden, :nickname, :note
+  )
+
+    # These should be in sync with choosealicense.com's collection defaults
+    DEFAULTS = {
+      'featured' => false,
+      'hidden'   => true
+    }.freeze
+
+    PREDICATE_FIELDS = %i[featured hidden].freeze
+
+    class << self
+      # Create a new LicenseMeta from YAML
+      #
+      # yaml - the raw YAML string
+      #
+      # returns a LicenseMeta with defaults set
+      def from_yaml(yaml)
+        return from_hash({}) if yaml.nil? || yaml.to_s.empty?
+        from_hash YAML.safe_load(yaml)
+      end
+
+      # Create a new LicenseMeta from a hash
+      #
+      # hash - the hash of key/value meta pairs
+      #
+      # returns a LicenseMeta with defaults set
+      def from_hash(hash)
+        hash = DEFAULTS.merge(hash)
+        hash['spdx_id'] = hash.delete('spdx-id')
+        ordered_array = hash.values_at(*members.map(&:to_s))
+        new(*ordered_array)
+      end
+
+      # Array of symbolized helper methods to expose on the License class
+      def helper_methods
+        members + PREDICATE_FIELDS.map { |f| "#{f}?".to_sym }
+      end
+    end
+
+    PREDICATE_FIELDS.each do |field|
+      alias_method "#{field}?".to_sym, field
+    end
+  end
+end

--- a/spec/licensee/license_meta_spec.rb
+++ b/spec/licensee/license_meta_spec.rb
@@ -1,0 +1,105 @@
+RSpec.describe Licensee::LicenseMeta do
+  subject { Licensee::License.find('mit').meta }
+
+  meta_fields.each do |field|
+    next if field['name'] == 'redirect_from'
+
+    context "the #{field['name']} field" do
+      let(:name) { field['name'].tr('-', '_') }
+      let(:method) { name.to_sym }
+
+      it 'responds to the field as a method' do
+        expect(subject).to respond_to(method)
+      end
+
+      it 'responds to the field as a hash key' do
+        if field['required']
+          expect(subject[name]).to_not be_nil
+        else
+          expect { subject[name] }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  context 'predicate methods' do
+    described_class::PREDICATE_FIELDS.each do |field|
+      context "the #{field}? method" do
+        it 'responds' do
+          expect(subject).to respond_to("#{field}?".to_sym)
+        end
+
+        it 'is boolean' do
+          expect(subject.send("#{field}?".to_sym)).to be(true).or be(false)
+        end
+      end
+    end
+  end
+
+  context '#from_hash' do
+    let(:hash) do
+      { 'title' => 'Test license', 'description' => 'A test license' }
+    end
+    subject { described_class.from_hash(hash) }
+
+    it 'sets values' do
+      expect(subject.title).to eql('Test license')
+      expect(subject.description).to eql('A test license')
+    end
+
+    context 'setting defaults' do
+      let(:hash) { {} }
+
+      described_class::DEFAULTS.each do |key, value|
+        it "sets the #{key} field to #{value}" do
+          expect(subject[key]).to eql(value)
+        end
+      end
+    end
+
+    context 'spdx-id' do
+      let(:hash) { { 'spdx-id' => 'foo' } }
+
+      it 'renames spdx-id to spdx_id' do
+        expect(subject['spdx_id']).to eql('foo')
+      end
+    end
+  end
+
+  context '#from_yaml' do
+    let(:yaml) { "title: Test license\ndescription: A test license" }
+    subject { described_class.from_yaml(yaml) }
+
+    it 'parses yaml' do
+      expect(subject.title).to eql('Test license')
+      expect(subject.description).to eql('A test license')
+    end
+
+    it 'sets defaults' do
+      expect(subject.hidden).to eql(true)
+      expect(subject.featured).to eql(false)
+    end
+
+    context 'nil yaml' do
+      let(:yaml) { nil }
+
+      it 'returns defaults' do
+        expect(subject.hidden).to eql(true)
+      end
+    end
+
+    context 'empty yaml' do
+      let(:yaml) { '' }
+
+      it 'returns defaults' do
+        expect(subject.featured).to eql(false)
+      end
+    end
+  end
+
+  it 'returns the list of helper methods' do
+    expect(described_class.helper_methods.length).to eql(15)
+    expect(described_class.helper_methods).to include(:hidden?)
+    expect(described_class.helper_methods).to include(:title)
+  end
+end

--- a/spec/licensee/license_meta_spec.rb
+++ b/spec/licensee/license_meta_spec.rb
@@ -98,8 +98,9 @@ RSpec.describe Licensee::LicenseMeta do
   end
 
   it 'returns the list of helper methods' do
-    expect(described_class.helper_methods.length).to eql(15)
+    expect(described_class.helper_methods.length).to eql(13)
     expect(described_class.helper_methods).to include(:hidden?)
+    expect(described_class.helper_methods).to_not include(:hidden)
     expect(described_class.helper_methods).to include(:title)
   end
 end

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -144,8 +144,9 @@ RSpec.describe Licensee::License do
   context 'meta' do
     it 'exposes license meta' do
       expect(mit).to respond_to(:meta)
-      expect(mit.meta).to have_key('title')
+      expect(mit.meta).to respond_to(:title)
       expect(mit.meta['title']).to eql('MIT License')
+      expect(mit.meta.title).to eql('MIT License')
     end
 
     it 'includes defaults' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,6 +66,12 @@ def format_percent(float)
   "#{format('%.2f', float)}%"
 end
 
+def meta_fields
+  path = 'vendor/choosealicense.com/_data/meta.yml'
+  path = File.expand_path(path, project_root)
+  YAML.safe_load(File.read(path))
+end
+
 RSpec::Matchers.define :be_an_existing_file do
   match { |path| File.exist?(path) }
 end


### PR DESCRIPTION
This PR introduces a LicenseMeta class to centralize the license meta handling logic in a dedicated class and to allow easier access to meta values by exposing all meta fields as, e.g., `license.spdx_id`, `license.hidden?`, etc.

Since Structs act like Hashes (e.g., `:[]`), this should be a backwards compatible change.

This will also allow us to enforce consistency around meta keys/values to make future breaking changes detectable (via a failing test). 