### PR TITLE
License#rules should return an object, not a hash of arrays

### DIFF
--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -2,11 +2,13 @@ require_relative 'licensee/version'
 require 'forwardable'
 require 'pathname'
 require 'rugged'
+require 'yaml'
 
 module Licensee
   autoload :ContentHelper, 'licensee/content_helper'
   autoload :License, 'licensee/license'
   autoload :LicenseMeta, 'licensee/license_meta'
+  autoload :LicenseRules, 'licensee/license_rules'
   autoload :Rule, 'licensee/rule'
   autoload :Matchers, 'licensee/matchers'
   autoload :Projects, 'licensee/projects'

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -134,19 +134,8 @@ module Licensee
       PSEUDO_LICENSES.include?(key)
     end
 
-    # Returns a hash in the form of rule_group => rules describing
-    # what you legally can and can't do with the given license
     def rules
-      return @rules if defined? @rules
-      @rules = {}
-
-      Rule.groups.each do |group|
-        @rules[group] = meta[group].map do |tag|
-          Rule.find_by_tag_and_group(tag, group)
-        end
-      end
-
-      @rules
+      @rules ||= LicenseRules.from_meta(meta)
     end
 
     def inspect

--- a/lib/licensee/license_meta.rb
+++ b/lib/licensee/license_meta.rb
@@ -1,5 +1,3 @@
-require 'yaml'
-
 module Licensee
   class LicenseMeta < Struct.new(
     :title, :spdx_id, :source, :description, :how, :conditions, :permissions,

--- a/lib/licensee/license_rules.rb
+++ b/lib/licensee/license_rules.rb
@@ -1,0 +1,34 @@
+module Licensee
+  # Exposes #conditions, #permissions, and #limitation arrays of LicenseRules
+  class LicenseRules < Struct.new(:conditions, :permissions, :limitations)
+    class << self
+      def from_license(license)
+        from_meta(license.meta)
+      end
+
+      def from_meta(meta)
+        rules = {}
+        Rule.groups.each do |group|
+          rules[group] = meta[group].map do |tag|
+            Rule.find_by_tag_and_group(tag, group)
+          end
+        end
+        from_hash(rules)
+      end
+
+      def from_hash(hash)
+        ordered_array = hash.values_at(*members.map(&:to_s))
+        new(*ordered_array)
+      end
+    end
+
+    def flatten
+      members.map { |m| public_send(m) }.flatten
+    end
+
+    def key?(key)
+      members.include?(key.to_sym)
+    end
+    alias has_key? key?
+  end
+end

--- a/spec/licensee/license_rules_spec.rb
+++ b/spec/licensee/license_rules_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Licensee::LicenseRules do
+  let(:mit) { Licensee::License.find('mit') }
+  subject { mit.rules }
+
+  Licensee::Rule.groups.each do |group|
+    context "the #{group} rule group" do
+      it 'responds as a hash key string' do
+        expect(subject[group]).to be_a(Array)
+      end
+
+      it 'responds as a hash key symbol' do
+        expect(subject[group.to_sym]).to be_a(Array)
+      end
+
+      it 'responds as a method' do
+        expect(subject.public_send(group.to_sym)).to be_a(Array)
+      end
+    end
+  end
+
+  context 'created from a license' do
+    subject { described_class.from_license(mit) }
+
+    it 'exposes the rules' do
+      expect(subject.permissions.first.label).to eql('Commercial use')
+    end
+  end
+
+  context 'created from a meta' do
+    subject { described_class.from_meta(mit.meta) }
+
+    it 'exposes the rules' do
+      expect(subject.permissions.first.label).to eql('Commercial use')
+    end
+  end
+
+  context 'created from a hash' do
+    let(:hash) { { 'permissions' => Licensee::Rule.all } }
+    subject { described_class.from_hash(hash) }
+
+    it 'exposes the rules' do
+      expect(subject.permissions.first.label).to eql('Commercial use')
+    end
+  end
+end

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -250,9 +250,10 @@ RSpec.describe Licensee::License do
   end
 
   it 'returns the rules' do
+    expect(mit.rules).to be_a(Licensee::LicenseRules)
     expect(mit.rules).to have_key('permissions')
     expect(mit.rules['permissions'].first).to be_a(Licensee::Rule)
-    expect(mit.rules.flatten.count).to eql(6)
+    expect(mit.rules.flatten.count).to eql(7)
   end
 
   it 'returns rules by tag and group' do


### PR DESCRIPTION
Following up on https://github.com/benbalter/licensee/pull/217 this moves `License#rules` to return a LicenseRules object, allowing you to, for example, use `license.rules.permissions` (or `license.rules[:permissions]`. Before only stringified keys were accepted, since it was a hash.

This allows us to centralize the rule logic in its own class and out of `License`. The change should be fully backwards compatible.