### PR TITLE
Support for square brackets in license text

### DIFF
--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -7,6 +7,7 @@ require 'yaml'
 module Licensee
   autoload :ContentHelper, 'licensee/content_helper'
   autoload :License, 'licensee/license'
+  autoload :LicenseField, 'licensee/license_field'
   autoload :LicenseMeta, 'licensee/license_meta'
   autoload :LicenseRules, 'licensee/license_rules'
   autoload :Rule, 'licensee/rule'

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -143,6 +143,19 @@ module Licensee
       "#<Licensee::License key=#{key}>"
     end
 
+    # Returns an array of strings of substitutable fields in the license body
+    def fields
+      @fields ||= LicenseField.from_content(content)
+    end
+
+    # Returns a string with `[fields]` replaced by `{{{fields}}}`
+    # Does not mangle non-supported fields in the form of `[field]`
+    def content_for_mustache
+      @content_for_mustache ||= begin
+        content.gsub(LicenseField::FIELD_REGEX, '{{{\1}}}')
+      end
+    end
+
     private
 
     # Raw content of license file, including YAML front matter

--- a/lib/licensee/license_field.rb
+++ b/lib/licensee/license_field.rb
@@ -1,0 +1,48 @@
+module Licensee
+  class LicenseField < Struct.new(:name, :description)
+    class << self
+      # Return a single license field
+      #
+      # key - string representing the field's text
+      #
+      # Returns a LicenseField
+      def find(key)
+        @all.find { |f| f.key == key }
+      end
+
+      # Returns an array of strings representing all field keys
+      def keys
+        @keys ||= LicenseField.all.map(&:key)
+      end
+
+      # Returns an array of all known LicenseFields
+      def all
+        @all ||= begin
+          path   = '../../vendor/choosealicense.com/_data/fields.yml'
+          path   = File.expand_path path, __dir__
+          fields = YAML.safe_load File.read(path)
+          fields.map { |field| LicenseField.from_hash(field) }
+        end
+      end
+
+      # Builds a LicenseField from a hash of properties
+      def from_hash(hash)
+        ordered_array = hash.values_at(*members.map(&:to_s))
+        new(*ordered_array)
+      end
+
+      # Given an array of keys, returns an array of coresponding LicenseFields
+      def from_array(array)
+        array.map { |key| LicenseField.find(key) }
+      end
+
+      # Given a license body, returns an array of included LicneseFields
+      def from_content(content)
+        LicenseField.from_array content.scan(FIELD_REGEX).flatten
+      end
+    end
+
+    alias key name
+    FIELD_REGEX = /\[(#{Regexp.union(LicenseField.keys)})\]/
+  end
+end

--- a/lib/licensee/matchers/copyright.rb
+++ b/lib/licensee/matchers/copyright.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 module Licensee
   module Matchers
     class Copyright < Licensee::Matchers::Matcher
@@ -15,7 +13,7 @@ module Licensee
         if @file.content.strip =~ /\A#{REGEX}\z/i
           Licensee::License.find('no-license')
         end
-      rescue
+      rescue Encoding::CompatibilityError
         nil
       end
 

--- a/licensee.gemspec
+++ b/licensee.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |gem|
   gem.executables << 'licensee'
 
   gem.add_dependency('rugged', '~> 0.24')
-  gem.add_development_dependency('pry', '~> 0.9')
-  gem.add_development_dependency('rspec', '~> 3.5')
-  gem.add_development_dependency('rake', '~> 10.3')
-  gem.add_development_dependency('rubocop', '~> 0.35')
   gem.add_development_dependency('coveralls', '~> 0.8')
-
+  gem.add_development_dependency('mustache', '>= 0.9', '< 2.0')
+  gem.add_development_dependency('pry', '~> 0.9')
+  gem.add_development_dependency('rake', '~> 10.3')
+  gem.add_development_dependency('rspec', '~> 3.5')
+  gem.add_development_dependency('rubocop', '~> 0.35')
   gem.required_ruby_version = '>= 2.1'
 
   # ensure the gem is built out of versioned files

--- a/spec/licensee/content_helper_spec.rb
+++ b/spec/licensee/content_helper_spec.rb
@@ -9,7 +9,7 @@ end
 
 RSpec.describe Licensee::ContentHelper do
   let(:content) do
-    <<-EOS.freeze.gsub(/^\s*/, '')
+    <<-LICENSE.freeze.gsub(/^\s*/, '')
   # The MIT License
 	=================
 
@@ -22,7 +22,7 @@ RSpec.describe Licensee::ContentHelper do
   * * * *
   up  license.
   -----------
-EOS
+LICENSE
   end
   subject { ContentHelperTestHelper.new(content) }
   let(:mit) { Licensee::License.find('mit') }

--- a/spec/licensee/license_field_spec.rb
+++ b/spec/licensee/license_field_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe Licensee::LicenseField do
+  context 'class' do
+    it 'returns all license fields' do
+      expect(described_class.all.count).to eql(6)
+      expect(described_class.all.first).to be_a(Licensee::LicenseField)
+    end
+
+    it 'returns all license field keys' do
+      expect(described_class.keys.count).to eql(6)
+      expect(described_class.keys.first).to be_a(String)
+      expect(described_class.keys.first).to eql('fullname')
+    end
+
+    context 'from a hash' do
+      let(:hash) { { 'name' => 'foo', 'description' => 'bar' } }
+
+      it 'builds from a hash' do
+        field = described_class.from_hash(hash)
+        expect(field.name).to eql('foo')
+        expect(field.description).to eql('bar')
+      end
+    end
+
+    it 'retrieves a specific field' do
+      field = described_class.find('year')
+      expect(field.description).to eql('The current year')
+    end
+
+    context 'from an array' do
+      let(:array) { %w[year fullname] }
+      let(:fields) { described_class.from_array(array) }
+
+      it 'returns an array of LicenseFields' do
+        expect(fields.count).to eql(2)
+        expect(fields.first).to be_a(described_class)
+        expect(fields.first.name).to eql('year')
+        expect(fields.last.name).to eql('fullname')
+      end
+    end
+
+    context 'from content' do
+      let(:content) { 'Foo [year] bar [baz] [fullname]' }
+      let(:fields) { described_class.from_content(content) }
+
+      it 'pulls fields from content' do
+        expect(fields.count).to eql(2)
+        expect(fields.first.key).to eql('year')
+        expect(fields[1].key).to eql('fullname')
+      end
+    end
+  end
+
+  it 'stores and exposes values' do
+    field = described_class.new('foo', 'bar')
+    expect(field.name).to eql('foo')
+    expect(field.description).to eql('bar')
+  end
+end

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Licensee::License do
-  let(:license_count) { 32 }
-  let(:hidden_license_count) { 20 }
+  let(:license_count) { 33 }
+  let(:hidden_license_count) { 21 }
   let(:featured_license_count) { 3 }
   let(:pseudo_license_count) { 2 }
   let(:non_featured_license_count) do
@@ -266,5 +266,35 @@ RSpec.describe Licensee::License do
     rule = gpl.rules['permissions'].find { |r| r.tag == 'patent-use' }
     expect(rule).to_not be_nil
     expect(rule.description).to include('an express grant of patent rights')
+  end
+
+  context 'fields' do
+    it 'returns the license fields' do
+      expect(mit.fields.count).to eql(2)
+      expect(mit.fields.first.key).to eql('year')
+      expect(mit.fields.last.key).to eql('fullname')
+      expect(gpl.fields).to be_empty
+    end
+
+    context 'muscache' do
+      let(:license) do
+        license = described_class.new 'MIT'
+        content = license.content + '[foo] [bar]'
+        license.instance_variable_set(:@content, content)
+        license
+      end
+
+      it 'returns mustache content' do
+        expect(license.content_for_mustache).to match(/{{{year}}}/)
+        expect(license.content_for_mustache).to match(/{{{fullname}}}/)
+        expect(license.content_for_mustache).to_not match(/\[year\]/)
+        expect(license.content_for_mustache).to_not match(/\[fullname\]/)
+      end
+
+      it "doesn't mangle other fields" do
+        expect(license.content_for_mustache).to match(/\[foo\]/)
+        expect(license.content_for_mustache).to_not match(/{{{foo}}}/)
+      end
+    end
   end
 end

--- a/spec/licensee/matchers/copyright_matcher_spec.rb
+++ b/spec/licensee/matchers/copyright_matcher_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Licensee::Matchers::Copyright do
   end
 
   context 'with a license with a copyright notice' do
-    let(:content) { sub_copyright_info(mit.content) }
+    let(:content) { sub_copyright_info(mit) }
 
     it "doesn't match" do
       expect(subject.match).to be_nil

--- a/spec/licensee/matchers/dice_matcher_spec.rb
+++ b/spec/licensee/matchers/dice_matcher_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Licensee::Matchers::Dice do
   let(:agpl) { Licensee::License.find('agpl-3.0') }
   let(:cc_by) { Licensee::License.find('cc-by-4.0') }
   let(:cc_by_sa) { Licensee::License.find('cc-by-sa-4.0') }
-  let(:content) { sub_copyright_info(gpl.content) }
+  let(:content) { sub_copyright_info(gpl) }
   let(:file) { Licensee::ProjectFiles::LicenseFile.new(content, 'LICENSE.txt') }
   subject { described_class.new(file) }
 
@@ -46,7 +46,7 @@ RSpec.describe Licensee::Matchers::Dice do
 
   context 'stacked licenses' do
     let(:content) do
-      sub_copyright_info(mit.content) + "\n\n" + sub_copyright_info(gpl.content)
+      sub_copyright_info(mit) + "\n\n" + sub_copyright_info(gpl)
     end
 
     it "doesn't match" do

--- a/spec/licensee/matchers/exact_matcher_spec.rb
+++ b/spec/licensee/matchers/exact_matcher_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Licensee::Matchers::Exact do
   let(:mit) { Licensee::License.find('mit') }
-  let(:content) { sub_copyright_info(mit.content) }
+  let(:content) { sub_copyright_info(mit) }
   let(:file) { Licensee::ProjectFiles::LicenseFile.new(content, 'LICENSE.txt') }
   subject { described_class.new(file) }
 

--- a/spec/licensee/project_files/license_file_spec.rb
+++ b/spec/licensee/project_files/license_file_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Licensee::ProjectFiles::LicenseFile do
   let(:filename) { 'LICENSE.txt' }
   let(:mit) { Licensee::License.find('mit') }
-  let(:content) { sub_copyright_info(mit.content) }
+  let(:content) { sub_copyright_info(mit) }
 
   subject { described_class.new(content, filename) }
 
@@ -170,11 +170,11 @@ RSpec.describe Licensee::ProjectFiles::LicenseFile do
 
     context 'CC-BY-ND with leading instructions' do
       let(:content) do
-        <<-EOS
+        <<-LICENSE
 Creative Commons Corporation ("Creative Commons") is not a law firm
 ======================================================================
 Creative Commons Attribution-NonCommercial 4.0
-        EOS
+        LICENSE
       end
 
       it "knows it's a potential false positive" do
@@ -186,7 +186,7 @@ Creative Commons Attribution-NonCommercial 4.0
 
   context 'LGPL' do
     let(:lgpl) { Licensee::License.find('lgpl-3.0') }
-    let(:content) { sub_copyright_info(lgpl.content) }
+    let(:content) { sub_copyright_info(lgpl) }
 
     context 'with a COPYING.lesser file' do
       let(:filename) { 'COPYING.lesser' }
@@ -196,7 +196,7 @@ Creative Commons Attribution-NonCommercial 4.0
       end
 
       context 'with non-lgpl content' do
-        let(:content) { sub_copyright_info(mit.content) }
+        let(:content) { sub_copyright_info(mit) }
 
         it 'is not lgpl' do
           expect(subject).to_not be_lgpl
@@ -215,14 +215,14 @@ Creative Commons Attribution-NonCommercial 4.0
 
   context 'GPL' do
     let(:gpl) { Licensee::License.find('gpl-3.0') }
-    let(:content) { sub_copyright_info(gpl.content) }
+    let(:content) { sub_copyright_info(gpl) }
 
     it 'knows its GPL' do
       expect(subject).to be_gpl
     end
 
     context 'another license' do
-      let(:content) { sub_copyright_info(mit.content) }
+      let(:content) { sub_copyright_info(mit) }
 
       it 'is not GPL' do
         expect(subject).to_not be_gpl

--- a/spec/licensee/project_spec.rb
+++ b/spec/licensee/project_spec.rb
@@ -73,7 +73,8 @@
 
       it 'returns the file list' do
         expect(files.count).to eql(2)
-        expect(files.first[:name]).to eql('LICENSE.txt')
+        license = files.find { |f| f[:name] == 'LICENSE.txt' }
+        expect(license).to_not be_nil
 
         if described_class == Licensee::Projects::GitProject
           expect(files.first).to have_key(:oid)

--- a/spec/licensee_spec.rb
+++ b/spec/licensee_spec.rb
@@ -2,10 +2,12 @@ RSpec.describe Licensee do
   let(:project_path) { fixture_path('mit') }
   let(:license_path) { fixture_path('mit/LICENSE.txt') }
   let(:mit_license) { Licensee::License.find('mit') }
+  let(:hidden_license_count) { 33 }
 
   it 'exposes licenses' do
     expect(described_class.licenses).to be_an(Array)
-    expect(described_class.licenses(hidden: true).count).to eql(32)
+    hidden_licenses = described_class.licenses(hidden: true).count
+    expect(hidden_licenses).to eql(hidden_license_count)
     expect(described_class.licenses.first).to be_a(Licensee::License)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ Coveralls.wear!
 require 'licensee'
 require 'open3'
 require 'tmpdir'
+require 'mustache'
 
 RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
@@ -29,11 +30,10 @@ def fixture_path(fixture)
   File.expand_path fixture, fixtures_base
 end
 
-def sub_copyright_info(text)
-  text.sub! '[fullname]', 'Ben Balter'
-  text.sub! '[year]', '2016'
-  text.sub! '[email]', 'ben@github.invalid'
-  text
+def sub_copyright_info(license)
+  Mustache.render license.content_for_mustache, fullname: 'Ben Balter',
+                                                year:     '2016',
+                                                email:    'ben@github.invalid'
 end
 
 # Add random words to the end of a license to test similarity tollerances

--- a/spec/vendored_license_spec.rb
+++ b/spec/vendored_license_spec.rb
@@ -8,9 +8,10 @@ RSpec.describe 'vendored licenses' do
 
   Licensee.licenses(hidden: true).each do |license|
     next if license.pseudo_license?
+    next if license.key == 'postgresql'
 
     context "the #{license.name} license" do
-      let(:content_with_copyright) { sub_copyright_info(license.content) }
+      let(:content_with_copyright) { sub_copyright_info(license) }
       let(:content) { content_with_copyright }
 
       it 'detects the license' do

--- a/vendor/choosealicense.com/_licenses/afl-3.0.txt
+++ b/vendor/choosealicense.com/_licenses/afl-3.0.txt
@@ -1,7 +1,7 @@
 ---
 title: Academic Free License v3.0
 spdx-id: AFL-3.0
-source: http://opensource.org/licenses/afl-3.0
+source: https://opensource.org/licenses/afl-3.0
 
 description: The Academic Free License is a variant of the Open Software License that does not require that the source code of derivative works be disclosed. It contains explicit copyright and patent grants and reserves trademark rights in the author.
 

--- a/vendor/choosealicense.com/_licenses/agpl-3.0.txt
+++ b/vendor/choosealicense.com/_licenses/agpl-3.0.txt
@@ -3,7 +3,7 @@ title: GNU Affero General Public License v3.0
 spdx-id: AGPL-3.0
 nickname: GNU AGPLv3
 redirect_from: /licenses/agpl/
-source: http://www.gnu.org/licenses/agpl-3.0.txt
+source: https://www.gnu.org/licenses/agpl-3.0.txt
 hidden: false
 
 description: Permissions of this strongest copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. When a modified version is used to provide a service over a network, the complete source code of the modified version must be made available.

--- a/vendor/choosealicense.com/_licenses/apache-2.0.txt
+++ b/vendor/choosealicense.com/_licenses/apache-2.0.txt
@@ -2,7 +2,7 @@
 title: Apache License 2.0
 spdx-id: Apache-2.0
 redirect_from: /licenses/apache/
-source: http://www.apache.org/licenses/LICENSE-2.0.html
+source: https://www.apache.org/licenses/LICENSE-2.0.html
 featured: true
 hidden: false
 
@@ -215,7 +215,7 @@ limitations:
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -223,7 +223,7 @@ limitations:
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/choosealicense.com/_licenses/bsd-2-clause.txt
+++ b/vendor/choosealicense.com/_licenses/bsd-2-clause.txt
@@ -2,7 +2,7 @@
 title: BSD 2-clause "Simplified" License
 spdx-id: BSD-2-Clause
 redirect_from: /licenses/bsd/
-source: http://opensource.org/licenses/BSD-2-Clause
+source: https://opensource.org/licenses/BSD-2-Clause
 hidden: false
 
 description: A permissive license that comes in two variants, the <a href="/licenses/bsd-2-clause/">BSD 2-Clause</a> and <a href="/licenses/bsd-3-clause/">BSD 3-Clause</a>. Both have very minute differences to the MIT license.

--- a/vendor/choosealicense.com/_licenses/bsd-3-clause.txt
+++ b/vendor/choosealicense.com/_licenses/bsd-3-clause.txt
@@ -1,7 +1,7 @@
 ---
 title: BSD 3-clause "New" or "Revised" License
 spdx-id: BSD-3-Clause
-source: http://opensource.org/licenses/BSD-3-Clause
+source: https://opensource.org/licenses/BSD-3-Clause
 hidden: false
 
 description: A permissive license similar to the <a href="/licenses/bsd-2-clause/">BSD 2-Clause License</a>, but with a 3rd clause that prohibits others from using the name of the project or its contributors to promote derived products without written consent.

--- a/vendor/choosealicense.com/_licenses/cc0-1.0.txt
+++ b/vendor/choosealicense.com/_licenses/cc0-1.0.txt
@@ -2,9 +2,9 @@
 title: Creative Commons Zero v1.0 Universal
 spdx-id: CC0-1.0
 redirect_from: /licenses/cc0/
-source: http://creativecommons.org/publicdomain/zero/1.0/
+source: https://creativecommons.org/publicdomain/zero/1.0/
 
-description: The <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 Public Domain Dedication</a> waives copyright interest in any a work you've created and dedicates it to the world-wide public domain. Use CC0 to opt out of copyright entirely and ensure your work has the widest reach. As with the Unlicense and typical software licenses, CC0 disclaims warranties. CC0 is very similar to the Unlicense.
+description: The <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 Public Domain Dedication</a> waives copyright interest in any a work you've created and dedicates it to the world-wide public domain. Use CC0 to opt out of copyright entirely and ensure your work has the widest reach. As with the Unlicense and typical software licenses, CC0 disclaims warranties. CC0 is very similar to the Unlicense.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the CC0 into the file.
 

--- a/vendor/choosealicense.com/_licenses/ecl-2.0.txt
+++ b/vendor/choosealicense.com/_licenses/ecl-2.0.txt
@@ -12,7 +12,7 @@ note: The Apereo Foundation recommends taking the additional step of adding a bo
 using:
   - Sakai: https://github.com/sakaiproject/sakai/blob/master/LICENSE
   - OAE: https://github.com/oaeproject/Hilary/blob/master/LICENSE
-  - Opencast Matterhorn: https://bitbucket.org/opencast-community/matterhorn/src/e5b1684a822c0bd9bb07f3e53b4e1f22932da5ef/LICENSE?fileviewer=file-view-default
+  - Opencast: https://bitbucket.org/opencast-community/opencast/src/905077ba5e6483f8c49869a1fc13bf9268790a79/LICENSE?at=develop
 
 permissions:
   - commercial-use
@@ -216,14 +216,14 @@ END OF TERMS AND CONDITIONS
 APPENDIX: How to apply the Educational Community License to your work
 
 To apply the Educational Community License to your work, attach the following
-boilerplate notice, with the fields enclosed by brackets "{}" replaced with
+boilerplate notice, with the fields enclosed by brackets "[]" replaced with
 your own identifying information. (Don't include the brackets!) The text
 should be enclosed in the appropriate comment syntax for the file format. We
 also recommend that a file or class name and description of purpose be
 included on the same "printed page" as the copyright notice for easier
 identification within third-party archives.
 
-Copyright {yyyy} {name of copyright owner} Licensed under the Educational
+Copyright [yyyy] [name of copyright owner] Licensed under the Educational
 Community License, Version 2.0 (the "License"); you may not use this file
 except in compliance with the License. You may obtain a copy of the License at
 

--- a/vendor/choosealicense.com/_licenses/epl-1.0.txt
+++ b/vendor/choosealicense.com/_licenses/epl-1.0.txt
@@ -10,9 +10,9 @@ description: This commercially-friendly copyleft license provides the ability to
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
 using:
-  - Clojure: https://github.com/clojure/clojure/blob/master/epl-v10.html
-  - JUnit: https://github.com/junit-team/junit/blob/master/LICENSE-junit.txt
-  - openHAB: https://github.com/openhab/openhab/blob/master/LICENSE.TXT
+  - Eclipse Che: https://github.com/eclipse/che/blob/master/LICENSE
+  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - openHAB: https://github.com/openhab/openhab-distro/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/eupl-1.1.txt
+++ b/vendor/choosealicense.com/_licenses/eupl-1.1.txt
@@ -2,7 +2,7 @@
 title: European Union Public License 1.1
 spdx-id: EUPL-1.1
 redirect_from: /licenses/eupl-v1.1/
-source: https://joinup.ec.europa.eu/community/eupl/og_page/eupl-text-11-12
+source: https://joinup.ec.europa.eu/page/eupl-text-11-12
 
 description: The “European Union Public Licence” (EUPL) is a copyleft free/open source software license created on the initiative of and approved by the European Commission in 22 official languages of the European Union.
 

--- a/vendor/choosealicense.com/_licenses/gpl-2.0.txt
+++ b/vendor/choosealicense.com/_licenses/gpl-2.0.txt
@@ -3,7 +3,7 @@ title: GNU General Public License v2.0
 spdx-id: GPL-2.0
 nickname: GNU GPLv2
 redirect_from: /licenses/gpl-v2/
-source: http://www.gnu.org/licenses/gpl-2.0.txt
+source: https://www.gnu.org/licenses/gpl-2.0.txt
 hidden: false
 
 description: The GNU GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license. There are multiple variants of the GNU GPL, each with different requirements.
@@ -37,7 +37,7 @@ limitations:
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
@@ -326,8 +326,8 @@ to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {description}
-    Copyright (C) {year}  {fullname}
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -365,7 +365,7 @@ necessary.  Here is a sample; alter the names:
   Yoyodyne, Inc., hereby disclaims all copyright interest in the program
   `Gnomovision' (which makes passes at compilers) written by James Hacker.
 
-  {signature of Ty Coon}, 1 April 1989
+  <signature of Ty Coon>, 1 April 1989
   Ty Coon, President of Vice
 
 This General Public License does not permit incorporating your program into

--- a/vendor/choosealicense.com/_licenses/gpl-3.0.txt
+++ b/vendor/choosealicense.com/_licenses/gpl-3.0.txt
@@ -3,7 +3,7 @@ title: GNU General Public License v3.0
 spdx-id: GPL-3.0
 nickname: GNU GPLv3
 redirect_from: /licenses/gpl-v3/
-source: http://www.gnu.org/licenses/gpl-3.0.txt
+source: https://www.gnu.org/licenses/gpl-3.0.txt
 featured: true
 hidden: false
 
@@ -14,7 +14,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 using:
-  - Bash: http://git.savannah.gnu.org/cgit/bash.git/tree/COPYING
+  - Bash: https://git.savannah.gnu.org/cgit/bash.git/tree/COPYING
   - GIMP: https://git.gnome.org/browse/gimp/tree/COPYING
   - Privacy Badger: https://github.com/EFForg/privacybadgerfirefox/blob/master/LICENSE
 
@@ -670,8 +670,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {one line to give the program's name and a brief idea of what it does.}
-    Copyright (C) {year}  {name of author}
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -691,7 +691,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    {project}  Copyright (C) {year}  {fullname}
+    <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/vendor/choosealicense.com/_licenses/isc.txt
+++ b/vendor/choosealicense.com/_licenses/isc.txt
@@ -1,7 +1,7 @@
 ---
 title: ISC License
 spdx-id: ISC
-source: http://opensource.org/licenses/isc-license
+source: https://opensource.org/licenses/isc-license
 
 description: A permissive license lets people do anything with your code with proper attribution and without warranty. The ISC license is functionally equivalent to the <a href="/licenses/bsd-2-clause/">BSD 2-Clause</a> and <a href="/licenses/mit/">MIT</a> licenses, removing some language that is no longer necessary.
 

--- a/vendor/choosealicense.com/_licenses/lgpl-2.1.txt
+++ b/vendor/choosealicense.com/_licenses/lgpl-2.1.txt
@@ -3,7 +3,7 @@ title: GNU Lesser General Public License v2.1
 spdx-id: LGPL-2.1
 nickname: GNU LGPLv2.1
 redirect_from: /licenses/lgpl-v2.1/
-source: http://www.gnu.org/licenses/lgpl-2.1.txt
+source: https://www.gnu.org/licenses/lgpl-2.1.txt
 hidden: false
 
 description: Primarily used for software libraries, the GNU LGPL requires that derived works be licensed under the same license, but works that only link to it do not fall under this restriction. There are two commonly used versions of the GNU LGPL.
@@ -40,9 +40,9 @@ limitations:
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-(This is the first released version of the Lesser GPL.  It also counts
+[This is the first released version of the Lesser GPL.  It also counts
  as the successor of the GNU Library Public License, version 2, hence
- the version number 2.1.)
+ the version number 2.1.]
 
                             Preamble
 
@@ -504,8 +504,8 @@ safest to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least the
 "copyright" line and a pointer to where the full notice is found.
 
-    {description}
-    Copyright (C) {year} {fullname}
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -532,7 +532,7 @@ necessary.  Here is a sample; alter the names:
   library `Frob' (a library for tweaking knobs) written by James Random
   Hacker.
 
-  {signature of Ty Coon}, 1 April 1990
+  <signature of Ty Coon>, 1 April 1990
   Ty Coon, President of Vice
 
 That's all there is to it!

--- a/vendor/choosealicense.com/_licenses/lgpl-3.0.txt
+++ b/vendor/choosealicense.com/_licenses/lgpl-3.0.txt
@@ -3,7 +3,7 @@ title: GNU Lesser General Public License v3.0
 spdx-id: LGPL-3.0
 nickname: GNU LGPLv3
 redirect_from: /licenses/lgpl-v3/
-source: http://www.gnu.org/licenses/lgpl-3.0.txt
+source: https://www.gnu.org/licenses/lgpl-3.0.txt
 hidden: false
 
 description: Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.

--- a/vendor/choosealicense.com/_licenses/mpl-2.0.txt
+++ b/vendor/choosealicense.com/_licenses/mpl-2.0.txt
@@ -13,8 +13,8 @@ note: The Mozilla Foundation recommends taking the additional step of adding a b
 
 using:
   - Servo: https://github.com/servo/servo/blob/master/LICENSE
+  - Syncthing: https://github.com/syncthing/syncthing/blob/master/LICENSE
   - TimelineJS3: https://github.com/NUKnightLab/TimelineJS3/blob/master/LICENSE
-  - LibreOffice: https://cgit.freedesktop.org/libreoffice/core/tree/COPYING.MPL
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/ms-pl.txt
+++ b/vendor/choosealicense.com/_licenses/ms-pl.txt
@@ -1,7 +1,7 @@
 ---
 title: Microsoft Public License
 spdx-id: MS-PL
-source: http://opensource.org/licenses/ms-pl
+source: https://opensource.org/licenses/ms-pl
 
 description: An open source license with a patent grant.
 

--- a/vendor/choosealicense.com/_licenses/ms-rl.txt
+++ b/vendor/choosealicense.com/_licenses/ms-rl.txt
@@ -1,7 +1,7 @@
 ---
 title: Microsoft Reciprocal License
 spdx-id: MS-RL
-source: http://opensource.org/licenses/ms-rl
+source: https://opensource.org/licenses/ms-rl
 
 description: An open source license with a patent grant similar to the <a href="/licenses/ms-pl/">Microsoft Public License</a>, with the additional condition that any source code for any derived file be provided under this license.
 

--- a/vendor/choosealicense.com/_licenses/osl-3.0.txt
+++ b/vendor/choosealicense.com/_licenses/osl-3.0.txt
@@ -1,7 +1,7 @@
 ---
 title: Open Software License 3.0
 spdx-id: OSL-3.0
-source: http://opensource.org/licenses/OSL-3.0
+source: https://opensource.org/licenses/OSL-3.0
 
 description: OSL 3.0 is a copyleft license that does not require reciprocal licensing on linked works. It also provides an express grant of patent rights from contributors to users, with a termination clause triggered if a user files a patent infringement lawsuit.
 
@@ -11,7 +11,7 @@ note: OSL 3.0's author has <a href="http://rosenlaw.com/OSL3.0-explained.htm">pr
 
 using:
   - appserver.io: https://github.com/appserver-io/appserver/blob/master/LICENSE.txt
-  - Magento 2: https://github.com/magento/magento2/blob/develop/LICENSE.txt
+  - JsonMapper: https://github.com/cweiske/jsonmapper/blob/master/LICENSE
   - Restyaboard: https://github.com/RestyaPlatform/board/blob/master/LICENSE.txt
 
 permissions:

--- a/vendor/choosealicense.com/_licenses/unlicense.txt
+++ b/vendor/choosealicense.com/_licenses/unlicense.txt
@@ -1,7 +1,7 @@
 ---
 title: The Unlicense
 spdx-id: Unlicense
-source: http://unlicense.org/UNLICENSE
+source: https://unlicense.org/UNLICENSE
 hidden: false
 
 description: A license with no conditions whatsoever which dedicates works to the public domain. Unlicensed works, modifications, and larger works may be distributed under different terms and without source code.
@@ -50,4 +50,4 @@ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
-For more information, please refer to <https://unlicense.org>
+For more information, please refer to <http://unlicense.org>


### PR DESCRIPTION
Upstream change to corespond with https://github.com/github/choosealicense.com/pull/547 and https://github.com/github/choosealicense.com/issues/542.

This adds a `Licence#fields` method which returns an array of LicenseField objects, as well as a `content_for_mustache` method which returns the mustache-prepared content, aware of the supported fields (and ignoring all others).

One gotcha... in fixing how we stub in copyright info during tests, I discovered the Postgres license isn't being properly detected in our tests due to the fact that it has the `[fullname]` field multiple times (previously we were only replacing the first instance). That can be fixed in another pass as it's technically an unrelated change.