### PR TITLE
Better handling of false 'others' due to multi-license support

### DIFF
--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -113,7 +113,7 @@ module Licensee
       titles = licenses.map(&:title_regex)
 
       # Title regex must include the version to support matching within
-      # families, but for sake of normilization, we can be less strict
+      # families, but for sake of normalization, we can be less strict
       without_versions = licenses.map do |license|
         next if license.title == license.name_without_version
         Regexp.new Regexp.escape(license.name_without_version), 'i'

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -126,10 +126,17 @@ module Licensee
         string = name.downcase.sub('*', 'u')
         string.sub!(/\Athe /i, '')
         string.sub!(/ license\z/i, '')
-        Regexp.new Regexp.escape(string), 'i'
+        string = Regexp.escape(string)
+        string = string.sub(/\bgnu\\ /, '(?:GNU )?')
+        Regexp.new string, 'i'
       end
 
-      @regex = Regexp.union [title_regex, key, meta.nickname].compact
+      parts = [title_regex, key]
+      if meta.nickname
+        parts.push Regexp.new meta.nickname.sub(/\bGNU /i, '(?:GNU )?')
+      end
+
+      @regex = Regexp.union parts
     end
 
     def other?

--- a/lib/licensee/matchers.rb
+++ b/lib/licensee/matchers.rb
@@ -1,14 +1,15 @@
 module Licensee
   module Matchers
-    autoload :Matcher, 'licensee/matchers/matcher'
-    autoload :Cabal, 'licensee/matchers/cabal'
+    autoload :Matcher,   'licensee/matchers/matcher'
+    autoload :Cabal,     'licensee/matchers/cabal'
     autoload :Copyright, 'licensee/matchers/copyright'
-    autoload :Cran, 'licensee/matchers/cran'
-    autoload :Dice, 'licensee/matchers/dice'
+    autoload :Cran,      'licensee/matchers/cran'
+    autoload :Dice,      'licensee/matchers/dice'
     autoload :DistZilla, 'licensee/matchers/dist_zilla'
-    autoload :Exact, 'licensee/matchers/exact'
-    autoload :Gemspec, 'licensee/matchers/gemspec'
-    autoload :NpmBower, 'licensee/matchers/npm_bower'
-    autoload :Package, 'licensee/matchers/package'
+    autoload :Exact,     'licensee/matchers/exact'
+    autoload :Gemspec,   'licensee/matchers/gemspec'
+    autoload :NpmBower,  'licensee/matchers/npm_bower'
+    autoload :Package,   'licensee/matchers/package'
+    autoload :Reference, 'licensee/matchers/reference'
   end
 end

--- a/lib/licensee/matchers/reference.rb
+++ b/lib/licensee/matchers/reference.rb
@@ -1,0 +1,16 @@
+module Licensee
+  module Matchers
+    # Matches README files that include a license by reference
+    class Reference < Licensee::Matchers::Matcher
+      def match
+        License.all(hidden: true, psuedo: false).find do |license|
+          /\b#{license.title_regex}\b/ =~ file.content
+        end
+      end
+
+      def confidence
+        raise 'Not implemented'
+      end
+    end
+  end
+end

--- a/lib/licensee/matchers/reference.rb
+++ b/lib/licensee/matchers/reference.rb
@@ -9,7 +9,7 @@ module Licensee
       end
 
       def confidence
-        raise 'Not implemented'
+        90
       end
     end
   end

--- a/lib/licensee/project_files/project_file.rb
+++ b/lib/licensee/project_files/project_file.rb
@@ -60,6 +60,14 @@ module Licensee
 
       alias match license
       alias path filename
+
+      # Is this file a COPYRIGHT file with only a copyright statement?
+      # If so, it can be excluded from determining if a project has >1 license
+      def copyright?
+        return false unless is_a?(LicenseFile)
+        return false unless matcher.is_a?(Matchers::Copyright)
+        filename =~ /\Acopyright(?:#{LicenseFile::ANY_EXT_REGEX})?\z/i
+      end
     end
   end
 end

--- a/lib/licensee/project_files/readme_file.rb
+++ b/lib/licensee/project_files/readme_file.rb
@@ -18,6 +18,10 @@ module Licensee
              \z)                 # End of file
         /mix
 
+      def possible_matchers
+        super.push(Matchers::Reference)
+      end
+
       def self.name_score(filename)
         SCORES.each do |pattern, score|
           return score if pattern =~ filename

--- a/lib/licensee/projects/project.rb
+++ b/lib/licensee/projects/project.rb
@@ -18,9 +18,9 @@ module Licensee
       # Returns the matching License instance if a license can be detected
       def license
         return @license if defined? @license
-        @license = if licenses.count == 1 || lgpl?
-          licenses.first
-        elsif licenses.count > 1
+        @license = if licenses_without_copyright.count == 1 || lgpl?
+          licenses_without_copyright.first
+        elsif licenses_without_copyright.count > 1
           Licensee::License.find('other')
         end
       end
@@ -135,6 +135,14 @@ module Licensee
 
       def project_files
         @project_files ||= [license_files, readme, package_file].flatten.compact
+      end
+
+      # Returns an array of matches licenses, excluding the COPYRIGHT file
+      # which can often be ignored for purposes of determing dual licensing
+      def licenses_without_copyright
+        @licenses_without_copyright ||= begin
+          matched_files.reject(&:copyright?).map(&:license).uniq
+        end
       end
     end
 

--- a/spec/fixtures/license-with-readme-reference/LICENSE
+++ b/spec/fixtures/license-with-readme-reference/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017 Ben Balter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/spec/fixtures/license-with-readme-reference/README
+++ b/spec/fixtures/license-with-readme-reference/README
@@ -1,0 +1,5 @@
+# Readme fixture
+
+## License
+
+[The MIT License](http://example.invalid)

--- a/spec/fixtures/mit-with-copyright/COPYRIGHT.md
+++ b/spec/fixtures/mit-with-copyright/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2017 Ben Balter

--- a/spec/fixtures/mit-with-copyright/LICENSE.txt
+++ b/spec/fixtures/mit-with-copyright/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Ben Balter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -148,6 +148,16 @@ RSpec.describe 'integration test' do
             expect(subject.license).to eql(license)
           end
         end
+
+        context 'license + README reference' do
+          let(:license) { Licensee::License.find('mit') }
+          let(:fixture) { 'license-with-readme-reference' }
+          let(:arguments) { { detect_readme: true } }
+
+          it 'determines the project is MIT' do
+            expect(subject.license).to eql(license)
+          end
+        end
       end
 
       context 'with the license file stubbed' do

--- a/spec/licensee/content_helper_spec.rb
+++ b/spec/licensee/content_helper_spec.rb
@@ -175,4 +175,69 @@ LICENSE
       end
     end
   end
+
+  context 'title regex' do
+    let(:license) { Licensee::License.find('gpl-3.0') }
+
+    %i[key title nickname name_without_version].each do |variation|
+      context "a license #{variation}" do
+        let(:license_variation) { license.send(variation) }
+        let(:text) { license_variation }
+
+        it 'matches' do
+          expect(text).to match(described_class.title_regex)
+        end
+
+        context 'preceded by the' do
+          let(:text) { "The #{license_variation} license" }
+
+          it 'matches' do
+            expect(text).to match(described_class.title_regex)
+          end
+        end
+
+        context 'with parens' do
+          let(:text) { "(#{license_variation})" }
+
+          it 'matches' do
+            expect(text).to match(described_class.title_regex)
+          end
+        end
+
+        context 'with parens and a preceding the' do
+          let(:text) { "(the #{license_variation} license)" }
+
+          it 'matches' do
+            expect(text).to match(described_class.title_regex)
+          end
+        end
+
+        context 'with whitespace' do
+          let(:text) { "     the #{license_variation} license" }
+
+          it 'matches' do
+            expect(text).to match(described_class.title_regex)
+          end
+        end
+
+        context 'escaping' do
+          let(:text) { 'gpl-3 0' }
+
+          it 'escapes' do
+            expect(text).to_not match(described_class.title_regex)
+          end
+        end
+
+        context 'in the middle of a string' do
+          let(:text) do
+            "The project is not licensed under the #{license_variation} license"
+          end
+
+          it 'matches' do
+            expect(text).to_not match(described_class.title_regex)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -352,6 +352,16 @@ RSpec.describe Licensee::License do
               expect(described_class.find_by_title(text)).to eql(license)
             end
 
+            if license.title =~ /\bGNU\b/
+              context "without 'GNU'" do
+                let(:text) { license_variation.sub(/GNU /i, '') }
+
+                it 'still matches' do
+                  expect(text).to match(license.title_regex)
+                end
+              end
+            end
+
             context "with 'the' and 'license'" do
               let(:text) { "The #{license_variation} license" }
 

--- a/spec/licensee/matchers/reference_matcher_spec.rb
+++ b/spec/licensee/matchers/reference_matcher_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Licensee::Matchers::Reference do
+  let(:content) { 'Copyright 2015 Ben Balter' }
+  let(:file) { Licensee::ProjectFiles::LicenseFile.new(content, 'LICENSE.txt') }
+  let(:license) { Licensee::License.find('gpl-3.0') }
+
+  subject { described_class.new(file) }
+
+  %i[title key nickname].each do |variation|
+    context "with a license #{variation}" do
+      let(:content) { "Licensed under the #{license.send(variation)} license" }
+
+      it 'matches' do
+        expect(subject.match).to eql(license)
+      end
+
+      context 'as a markdown link' do
+        let(:content) { "[#{license.send(variation)}](https://example.com)" }
+
+        it 'matches' do
+          expect(subject.match).to eql(license)
+        end
+      end
+    end
+  end
+
+  context 'a license key in a word' do
+    let(:content) { 'My name is MITch!' }
+
+    it "doesn't match" do
+      expect(subject.match).to be_nil
+    end
+  end
+
+  context 'a license with alt regex' do
+    let(:content) { 'Clear BSD' }
+    let(:license) { Licensee::License.find('bsd-3-clause-clear') }
+
+    it 'matches' do
+      expect(subject.match).to eql(license)
+    end
+  end
+end

--- a/spec/licensee/project_files/license_file_spec.rb
+++ b/spec/licensee/project_files/license_file_spec.rb
@@ -238,4 +238,31 @@ Creative Commons Attribution-NonCommercial 4.0
       expect(subject.license).to eql(other)
     end
   end
+
+  context 'copyright?' do
+    context 'a copyright file' do
+      let(:content) { 'Copyright 2017 Ben Balter' }
+      let(:filename) { 'COPYRIGHT.txt' }
+
+      it "knows it's a copyright file" do
+        expect(subject.send(:copyright?)).to be_truthy
+      end
+    end
+
+    context 'A copyright file with license text' do
+      let(:filename) { 'COPYRIGHT.txt' }
+
+      it "knows it's not a copyright file" do
+        expect(subject.send(:copyright?)).to be_falsy
+      end
+    end
+
+    context 'a license file with copyright text' do
+      let(:content) { 'Copyright 2017 Ben Balter' }
+
+      it "knows it's not a copyright file" do
+        expect(subject.send(:copyright?)).to be_falsy
+      end
+    end
+  end
 end

--- a/spec/licensee/project_files/readme_spec.rb
+++ b/spec/licensee/project_files/readme_spec.rb
@@ -98,4 +98,13 @@ RSpec.describe Licensee::ProjectFiles::ReadmeFile do
       end
     end
   end
+
+  context 'a license reference' do
+    let(:content) { 'The MIT License' }
+    let(:mit) { Licensee::License.find('mit') }
+
+    it 'matches' do
+      expect(subject.match).to eql(mit)
+    end
+  end
 end

--- a/spec/licensee/project_spec.rb
+++ b/spec/licensee/project_spec.rb
@@ -240,5 +240,13 @@
         expect(subject.license_files.last.filename).to eql('LICENSE')
       end
     end
+
+    context 'with a copyright file' do
+      let(:fixture) { 'mit-with-copyright' }
+
+      it 'returns MIT' do
+        expect(subject.license).to eql(mit)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR attempts to tackle #230 and #222 in related but distinct ways:

1. If a `COPYRIGHT` file is present and contains only copyright notice (the existing copyright matcher), don't count it as a second license for purposes of determining dual licensing.

2. If a consumer opts in into checking the README, and the README contains a *reference* to a known license (title, nickname, or key), consider the README as indicating license to prevent cases when a LICENSE file says one licence and the README contains a license heading, but not the license text, causing a false `other`. This is implemented as the `Reference` matcher, available only to README files.

To accomplish the above I added:

1. A `License#find_by_title` method, which matches on title, nickname, or key.
2. Added a `pseudo` argument to `License#all` to exclude `other` and `no-license`

One gotcha to call out:

To keep the logic in `Project` simple, I opted to add the new logic as a matcher. That means, that if a consumer opts into README file detection, it'll be naive, in that if a README has a license section with `The MIT License`, and nothing else (and no license file), the project as a whole will be considered MIT. 

In #222 we talked about only employing that strategy when the license is detected by other means, and the README license is consistent with that other license. That's possible to implement, but would add some complexity, so I wanted to pause and check in before I went any further.

Fixes https://github.com/benbalter/licensee/issues/230. Fixes https://github.com/benbalter/licensee/issues/222.