### PR TITLE
Allow version notation to be more lenient

### DIFF
--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -86,7 +86,6 @@ module Licensee
     }.freeze
 
     ALT_TITLE_REGEX = {
-      'apache-2.0'         => /apache license(?:, version)? 2.0/i,
       'bsd-2-clause'       => /bsd 2-clause(?: \"simplified\")?/i,
       'bsd-3-clause'       => /bsd 3-clause(?: \"new\" or \"revised\")?/i,
       'bsd-3-clause-clear' => /(?:clear bsd|bsd 3-clause(?: clear)?)/i
@@ -127,7 +126,10 @@ module Licensee
         string = name.downcase.sub('*', 'u')
         string.sub!(/\Athe /i, '')
         string.sub!(/ license\z/i, '')
+        string.sub!(/,? version /, ' ')
+        string.sub!(/v(\d+\.\d+)/, '\1')
         string = Regexp.escape(string)
+        string = string.sub(/ (\d+\\.\d+)/, ',?\ (?:version\ |v)?\1')
         string = string.sub(/\bgnu\\ /, '(?:GNU )?')
         Regexp.new string, 'i'
       end

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -369,6 +369,40 @@ RSpec.describe Licensee::License do
                 expect(text).to match(license.title_regex)
               end
             end
+
+            if variation == :title
+              context 'version notation variations' do
+                context "with 'version x.x'" do
+                  let(:text) do
+                    license_variation.sub(/v?(\d+\.\d+)/i, 'version \1')
+                  end
+
+                  it 'matches' do
+                    expect(text).to match(license.title_regex)
+                  end
+                end
+
+                context "with ', version x.x'" do
+                  let(:text) do
+                    license_variation.sub(/ v?(\d+\.\d+)/i, ', version \1')
+                  end
+
+                  it 'matches' do
+                    expect(text).to match(license.title_regex)
+                  end
+                end
+
+                context "with 'vx.x'" do
+                  let(:text) do
+                    license_variation.sub(/(?:version)? (\d+\.\d+)/i, ' v\1')
+                  end
+
+                  it 'matches' do
+                    expect(text).to match(license.title_regex)
+                  end
+                end
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
As discussed in https://github.com/benbalter/licensee/pull/235#issuecomment-343974853, this PR updates the license title regex to be agnostic to the following version notation formats:

* `The foo license 1.0`
* `The foo license v1.0`
* `The foo license version 1.0`
* `The foo license, version 1.0`
* `The foo license, v1.0`

The idea being, that in all of the above formats, the author's intent is unambiguous, and thus our regex should accept each variation as the matching license.

