### PR TITLE
Allow ReferenceMatcher to match references to licenses by their source

### DIFF
--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -92,6 +92,9 @@ module Licensee
       'bsd-3-clause-clear' => /(?:clear bsd|bsd 3-clause(?: clear)?)/i
     }.freeze
 
+    SOURCE_PREFIX = %r{https?://(?:www\.)?}i
+    SOURCE_SUFFIX = %r{(?:\.html?|\.txt|\/)}i
+
     include Licensee::ContentHelper
     extend Forwardable
     def_delegators :meta, *LicenseMeta.helper_methods
@@ -120,7 +123,7 @@ module Licensee
     end
 
     def title_regex
-      return @regex if defined? @regex
+      return @title_regex if defined? @title_regex
 
       title_regex = ALT_TITLE_REGEX[key]
       title_regex ||= begin
@@ -137,7 +140,26 @@ module Licensee
         parts.push Regexp.new meta.nickname.sub(/\bGNU /i, '(?:GNU )?')
       end
 
-      @regex = Regexp.union parts
+      @title_regex = Regexp.union parts
+    end
+
+    # Returns a regex that will match the license source
+    #
+    # The following variations are supported (as presumed identical):
+    # 1. HTTP or HTTPS
+    # 2. www or non-www
+    # 3. .txt, .html, .htm, or / suffix
+    #
+    # Returns the regex, or nil if no source exists
+    def source_regex
+      return @source_regex if defined? @source_regex
+      return unless meta.source
+
+      source = meta.source.dup.sub(/\A#{SOURCE_PREFIX}/, '')
+      source = source.sub(/#{SOURCE_SUFFIX}\z/, '')
+
+      escaped_source = Regexp.escape(source)
+      @source_regex = /#{SOURCE_PREFIX}#{escaped_source}(?:#{SOURCE_SUFFIX})?/i
     end
 
     def other?

--- a/lib/licensee/matchers/reference.rb
+++ b/lib/licensee/matchers/reference.rb
@@ -4,7 +4,8 @@ module Licensee
     class Reference < Licensee::Matchers::Matcher
       def match
         License.all(hidden: true, psuedo: false).find do |license|
-          /\b#{license.title_regex}\b/ =~ file.content
+          title_or_source = [license.title_regex, license.source_regex].compact
+          /\b#{Regexp.union(title_or_source)}\b/ =~ file.content
         end
       end
 

--- a/spec/licensee/matchers/reference_matcher_spec.rb
+++ b/spec/licensee/matchers/reference_matcher_spec.rb
@@ -39,4 +39,13 @@ RSpec.describe Licensee::Matchers::Reference do
       expect(subject.match).to eql(license)
     end
   end
+
+  context 'with a license source' do
+    let(:license) { Licensee::License.find('mpl-2.0') }
+    let(:content) { "The [license](#{license.source})" }
+
+    it 'matches' do
+      expect(subject.match).to eql(license)
+    end
+  end
 end


### PR DESCRIPTION
As suggested in https://github.com/benbalter/licensee/pull/237#issuecomment-344056185, this PR updates ReferenceMatcher to match references to licenses by their source (as defined by choosealicense.com).

To allow for human error, the following permutations are ignored/considered to be the same intent:

* `http` or `https`
* `www.` and non-www
* `.txt`, `.html`, `.htm`, or `/` suffix (or no suffix)

Thoughts? This would only be used if the ReferenceMatcher is used, right now if a downstream users opts into readme detection support.