### PR TITLE
Extend gemspec pattern matching

### DIFF
--- a/lib/licensee/matchers/gemspec.rb
+++ b/lib/licensee/matchers/gemspec.rb
@@ -28,10 +28,18 @@ module Licensee
         match = @file.content.match LICENSE_REGEX
         return match[1].downcase if match && match[1]
 
-        # this will capture each value in the license array
-        # for now only return the first match
+        # check for a licenses array property
+        licenses = license_array_property
+        return unless licenses
+
+        # use 'other' if array contains multiple licenses
+        return 'other' unless licenses.size == 1
+        licenses[0]
+      end
+
+      def license_array_property
         match = @file.content.match LICENSE_ARRAY_REGEX
-        match[1].downcase if match && match[1]
+        match.captures.compact.map(&:downcase) if match
       end
 
       def declarations

--- a/lib/licensee/matchers/gemspec.rb
+++ b/lib/licensee/matchers/gemspec.rb
@@ -2,7 +2,8 @@ module Licensee
   module Matchers
     class Gemspec < Licensee::Matchers::Package
       # a value is a string surrounded by any amount of whitespace
-      VALUE_REGEX = /\s*[\'\"]([a-z\-0-9\.]+)[\'\"]\s*/i
+      # optionally ended with (non-captured) ".freeze"
+      VALUE_REGEX = /\s*[\'\"]([a-z\-0-9\.]+)[\'\"](?:\.freeze)?\s*/i
 
       # an array contains one or more values. all values, or array itself,
       # can be surrounded by any amount of whitespace.  do not capture

--- a/lib/licensee/matchers/gemspec.rb
+++ b/lib/licensee/matchers/gemspec.rb
@@ -1,18 +1,35 @@
 module Licensee
   module Matchers
     class Gemspec < Licensee::Matchers::Package
+      # a value is a string surrounded by any amount of whitespace
+      VALUE_REGEX = /\s*[\'\"]([a-z\-0-9\.]+)[\'\"]\s*/i
+
+      # an array contains one or more values. all values, or array itself,
+      # can be surrounded by any amount of whitespace.  do not capture
+      # non-value groups
+      ARRAY_REGEX = /\s*\[#{VALUE_REGEX}(?:,#{VALUE_REGEX})*\]\s*/i
+
       DECLARATION_REGEX = /
-        ^\s*[a-z0-9_]+\.([a-z0-9_]+)\s*\=\s*[\'\"]([a-z\-0-9\.]+)[\'\"]\s*$
-        /ix
+        ^\s*[a-z0-9_]+\.([a-z0-9_]+)\s*\=#{VALUE_REGEX}$
+      /ix
 
       LICENSE_REGEX = /
-           ^\s*[a-z0-9_]+\.license\s*\=\s*[\'\"]([a-z\-0-9\.]+)[\'\"]\s*$
-           /ix
+        ^\s*[a-z0-9_]+\.license\s*\=#{VALUE_REGEX}$
+      /ix
+
+      LICENSE_ARRAY_REGEX = /
+        ^\s*[a-z0-9_]+\.licenses\s*\=#{ARRAY_REGEX}$
+      /ix
 
       private
 
       def license_property
         match = @file.content.match LICENSE_REGEX
+        return match[1].downcase if match && match[1]
+
+        # this will capture each value in the license array
+        # for now only return the first match
+        match = @file.content.match LICENSE_ARRAY_REGEX
         match[1].downcase if match && match[1]
       end
 

--- a/spec/licensee/matchers/gemspec_matcher_spec.rb
+++ b/spec/licensee/matchers/gemspec_matcher_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Licensee::Matchers::Gemspec do
     'double quotes' => 's.license = "mit"',
     'no whitespace' => "s.license='mit'",
     'uppercase'     => "s.license = 'MIT'",
-    'array'         => "s.licenses = ['mit' , 'bsd-3-clause']",
+    'array'         => "s.licenses = ['mit']",
     'frozen'        => "s.license = 'mit'.freeze"
   }.each do |description, license_declaration|
     context "with a #{description} declaration" do
@@ -41,6 +41,14 @@ RSpec.describe Licensee::Matchers::Gemspec do
 
   context 'an unknown license' do
     let(:content) { "s.license = 'foo'" }
+
+    it 'returns other' do
+      expect(subject.match).to eql(Licensee::License.find('other'))
+    end
+  end
+
+  context 'a licenses property with multiple licenses' do
+    let(:content) { "s.licenses = ['mit', 'bsd-3-clause']" }
 
     it 'returns other' do
       expect(subject.match).to eql(Licensee::License.find('other'))

--- a/spec/licensee/matchers/gemspec_matcher_spec.rb
+++ b/spec/licensee/matchers/gemspec_matcher_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Licensee::Matchers::Gemspec do
     'as spec.'      => "spec.license = 'mit'",
     'double quotes' => 's.license = "mit"',
     'no whitespace' => "s.license='mit'",
-    'uppercase'     => "s.license = 'MIT'"
+    'uppercase'     => "s.license = 'MIT'",
+    'array'         => "s.licenses = ['mit']"
   }.each do |description, license_declaration|
     context "with a #{description} declaration" do
       let(:content) { license_declaration }

--- a/spec/licensee/matchers/gemspec_matcher_spec.rb
+++ b/spec/licensee/matchers/gemspec_matcher_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Licensee::Matchers::Gemspec do
     'double quotes' => 's.license = "mit"',
     'no whitespace' => "s.license='mit'",
     'uppercase'     => "s.license = 'MIT'",
-    'array'         => "s.licenses = ['mit']",
+    'array'         => "s.licenses = ['mit' , 'bsd-3-clause']",
     'frozen'        => "s.license = 'mit'.freeze"
   }.each do |description, license_declaration|
     context "with a #{description} declaration" do

--- a/spec/licensee/matchers/gemspec_matcher_spec.rb
+++ b/spec/licensee/matchers/gemspec_matcher_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Licensee::Matchers::Gemspec do
     'double quotes' => 's.license = "mit"',
     'no whitespace' => "s.license='mit'",
     'uppercase'     => "s.license = 'MIT'",
-    'array'         => "s.licenses = ['mit']"
+    'array'         => "s.licenses = ['mit']",
+    'frozen'        => "s.license = 'mit'.freeze"
   }.each do |description, license_declaration|
     context "with a #{description} declaration" do
       let(:content) { license_declaration }


### PR DESCRIPTION
Found a few issues with parsing the `license` field out of a gemspec.

1. The gem specification allows for a `licenses` array field that wasn't found and captured.
2. The pattern didn't match on frozen strings, e.g. `"mit".freeze`

Ruby allows regex's to be interpolated inside other regex's which makes the array regex much easier to understand and work with.  It also made it simpler to ensure values were treated equally among all of the regular expressions.

The only captured group in these regex's is the license text.  All other groups are non-capturing with `(?: ...)`.  Meaning in an array like `["mit", "bsd-3-clause"]`, `match[1] == "mit"` and `match[2] == "bsd-3-clause"`

Only the first array value is used, to match current functionality.