### PR TITLE
Use webmock to test stub Octokit responses

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spec/fixtures/shared-test-fixture"]
+	path = spec/fixtures/shared-test-fixture
+	url = https://github.com/benbalter/licensee-test-fixture

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "spec/fixtures/shared-test-fixture"]
-	path = spec/fixtures/shared-test-fixture
-	url = https://github.com/benbalter/licensee-test-fixture

--- a/licensee.gemspec
+++ b/licensee.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rake', '~> 10.3')
   gem.add_development_dependency('rspec', '~> 3.5')
   gem.add_development_dependency('rubocop', '~> 0.35')
+  gem.add_development_dependency('webmock', '~> 3.1')
+
   gem.required_ruby_version = '>= 2.1'
 
   # ensure the gem is built out of versioned files

--- a/script/git-repo
+++ b/script/git-repo
@@ -4,7 +4,7 @@
 set -e
 
 repo=$1
-name=$(basename $repo)
+name=$(basename "$repo")
 dir="./tmp/$name"
 rm -Rf "$dir"
 
@@ -12,8 +12,8 @@ bundle exec bin/licensee "$repo"
 
 if [ "$2" = "--license" ]; then
   git clone --depth 1 --quiet "$repo" "$dir"
-  license_path=$(bundle exec ./script/license-path $dir)
-  cat $license_path | bundle exec script/diff $3
+  license_path=$(bundle exec ./script/license-path "$dir")
+  bundle exec script/diff $3 < "$license_path"
 fi
 
 rm -Rf "$dir"

--- a/script/git-repo
+++ b/script/git-repo
@@ -8,10 +8,10 @@ name=$(basename $repo)
 dir="./tmp/$name"
 rm -Rf "$dir"
 
-git clone --depth 1 --quiet "$repo" "$dir"
-bundle exec bin/licensee "$dir"
+bundle exec bin/licensee "$repo"
 
 if [ "$2" = "--license" ]; then
+  git clone --depth 1 --quiet "$repo" "$dir"
   license_path=$(bundle exec ./script/license-path $dir)
   cat $license_path | bundle exec script/diff $3
 fi

--- a/spec/fixtures/gemspec/project.gemspec
+++ b/spec/fixtures/gemspec/project.gemspec
@@ -1,0 +1,5 @@
+# Using a `.gemspec` extension here breaks the `gem release` command
+Gem::Specification.new do |gem|
+  gem.name = "licensee-fixture-project"
+  gem.license = 'mit'
+end

--- a/spec/fixtures/gemspec/project.gemspec
+++ b/spec/fixtures/gemspec/project.gemspec
@@ -1,5 +1,0 @@
-# Using a `.gemspec` extension here breaks the `gem release` command
-Gem::Specification.new do |gem|
-  gem.name = "licensee-fixture-project"
-  gem.license = 'mit'
-end

--- a/spec/fixtures/webmock/licensee.json
+++ b/spec/fixtures/webmock/licensee.json
@@ -1,0 +1,26 @@
+[
+  {
+   "name":         "LICENSE.txt",
+   "path":         "LICENSE.txt",
+   "sha":          "sha1",
+   "size":         1072,
+   "url":          "https://api.github.com/repos/benbalter/licensee/contents/LICENSE.txt?ref=master",
+   "html_url":     "https://github.com/benbalter/licensee/blob/master/LICENSE.txt",
+   "git_url":      "https://api.github.com/repos/benbalter/licensee/git/blobs/sha1",
+   "download_url": "https://raw.githubusercontent.com/benbalter/licensee/master/LICENSE.txt",
+   "type":         "file",
+   "_links":       {}
+  },
+  {
+   "name":         "README.md",
+   "path":         "README.md",
+   "sha":          "sha2",
+   "size":         13420,
+   "url":          "https://api.github.com/repos/benbalter/licensee/contents/README.md?ref=master",
+   "html_url":     "https://github.com/benbalter/licensee/blob/master/README.md",
+   "git_url":      "https://api.github.com/repos/benbalter/licensee/git/blobs/sha2",
+   "download_url": "https://raw.githubusercontent.com/benbalter/licensee/master/README.md",
+   "type":         "file",
+   "_links":       {}
+  }
+]

--- a/spec/licensee/project_spec.rb
+++ b/spec/licensee/project_spec.rb
@@ -9,6 +9,7 @@
     let(:other) { Licensee::License.find('other') }
     let(:fixture) { 'mit' }
     let(:path) { fixture_path(fixture) }
+    let(:api_base) { 'https://api.github.com/repos' }
     subject { described_class.new(path) }
 
     if described_class == Licensee::Projects::GitProject
@@ -27,16 +28,18 @@
       end
     elsif described_class == Licensee::Projects::GitHubProject
       let(:path) do
-        stub_request(:get, "https://api.github.com/repos/#{stubbed_org}/#{fixture}/contents/")
-          .to_return(
-            status:  200,
-            body:    fixture_root_contents_from_api(fixture),
-            headers: { 'Content-Type' => 'application/json' }
-          )
+        stub_request(
+          :get, "#{api_base}/#{stubbed_org}/#{fixture}/contents/"
+        ).to_return(
+          status:  200,
+          body:    fixture_root_contents_from_api(fixture),
+          headers: { 'Content-Type' => 'application/json' }
+        )
 
         fixture_root_files(fixture).each do |file|
           relative_path = File.basename(file)
-          stub_request(:get, "https://api.github.com/repos/#{stubbed_org}/#{fixture}/contents/#{relative_path}")
+          parts = [api_base, stubbed_org, fixture, 'contents', relative_path]
+          stub_request(:get, parts.join('/'))
             .with(headers: { 'accept' => 'application/vnd.github.v3.raw' })
             .to_return(status: 200, body: File.read(file))
         end
@@ -164,7 +167,9 @@
 
       # Using a `.gemspec` extension in the fixture breaks `gem release`
       before do
-        FileUtils.cp("#{fixture_path(fixture)}/project._gemspec", "#{fixture_path(fixture)}/project.gemspec")
+        from = "#{fixture_path(fixture)}/project._gemspec"
+        to   = "#{fixture_path(fixture)}/project.gemspec"
+        FileUtils.cp(from, to)
         if described_class == Licensee::Projects::GitProject
           Dir.chdir fixture_path(fixture) do
             `git add project.gemspec`

--- a/spec/licensee/project_spec.rb
+++ b/spec/licensee/project_spec.rb
@@ -1,6 +1,10 @@
-[Licensee::Projects::FSProject,
- Licensee::Projects::GitProject].each do |project_type|
+[
+  Licensee::Projects::FSProject,
+  Licensee::Projects::GitProject,
+  Licensee::Projects::GitHubProject
+].each do |project_type|
   RSpec.describe project_type do
+    let(:stubbed_org) { '_licensee_test_fixture' }
     let(:mit) { Licensee::License.find('mit') }
     let(:other) { Licensee::License.find('other') }
     let(:fixture) { 'mit' }
@@ -20,6 +24,24 @@
       after do
         subject.close
         FileUtils.rm_rf File.expand_path '.git', path
+      end
+    elsif described_class == Licensee::Projects::GitHubProject
+      let(:path) do
+        stub_request(:get, "https://api.github.com/repos/#{stubbed_org}/#{fixture}/contents/")
+          .to_return(
+            status:  200,
+            body:    fixture_root_contents_from_api(fixture),
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        fixture_root_files(fixture).each do |file|
+          relative_path = File.basename(file)
+          stub_request(:get, "https://api.github.com/repos/#{stubbed_org}/#{fixture}/contents/#{relative_path}")
+            .with(headers: { 'accept' => 'application/vnd.github.v3.raw' })
+            .to_return(status: 200, body: File.read(file))
+        end
+
+        "https://github.com/#{stubbed_org}/#{fixture}"
       end
     end
 
@@ -142,9 +164,9 @@
 
       # Using a `.gemspec` extension in the fixture breaks `gem release`
       before do
-        FileUtils.cp("#{path}/project._gemspec", "#{path}/project.gemspec")
+        FileUtils.cp("#{fixture_path(fixture)}/project._gemspec", "#{fixture_path(fixture)}/project.gemspec")
         if described_class == Licensee::Projects::GitProject
-          Dir.chdir path do
+          Dir.chdir fixture_path(fixture) do
             `git add project.gemspec`
             `git commit -m 'add real gemspec'`
           end
@@ -152,7 +174,7 @@
       end
 
       after do
-        FileUtils.rm("#{path}/project.gemspec")
+        FileUtils.rm("#{fixture_path(fixture)}/project.gemspec")
       end
 
       subject { described_class.new(path, detect_packages: true) }

--- a/spec/licensee/projects/github_project_spec.rb
+++ b/spec/licensee/projects/github_project_spec.rb
@@ -40,44 +40,20 @@ RSpec.describe Licensee::Projects::GitHubProject do
 
   context 'when the repo exists' do
     before do
-      allow(Octokit)
-        .to receive(:contents)
-        .with('benbalter/licensee')
-        .and_return([
-                      {
-                        name:         'LICENSE.txt',
-                        path:         'LICENSE.txt',
-                        sha:          'sha1',
-                        size:         1072,
-                        url:          'https://api.github.com/repos/benbalter/licensee/contents/LICENSE.txt?ref=master',
-                        html_url:     'https://github.com/benbalter/licensee/blob/master/LICENSE.txt',
-                        git_url:      'https://api.github.com/repos/benbalter/licensee/git/blobs/sha1',
-                        download_url: 'https://raw.githubusercontent.com/benbalter/licensee/master/LICENSE.txt',
-                        type:         'file',
-                        _links:       {}
-                      },
-                      { name:         'README.md',
-                        path:         'README.md',
-                        sha:          'sha2',
-                        size:         13_420,
-                        url:          'https://api.github.com/repos/benbalter/licensee/contents/README.md?ref=master',
-                        html_url:     'https://github.com/benbalter/licensee/blob/master/README.md',
-                        git_url:      'https://api.github.com/repos/benbalter/licensee/git/blobs/sha2',
-                        download_url: 'https://raw.githubusercontent.com/benbalter/licensee/master/README.md',
-                        type:         'file',
-                        _links:       {} }
-                    ])
+      stub_request(:get, 'https://api.github.com/repos/benbalter/licensee/contents/')
+        .to_return(
+          status:  200,
+          body:    fixture_contents('webmock/licensee.json'),
+          headers: { 'Content-Type' => 'application/json' }
+        )
 
-      allow(Octokit)
-        .to receive(:contents)
-        .with(repo, path:   'LICENSE.txt',
-                    accept: 'application/vnd.github.v3.raw')
-        .and_return(license_file)
+      stub_request(:get, 'https://api.github.com/repos/benbalter/licensee/contents/LICENSE.txt')
+        .with(headers: { 'accept' => 'application/vnd.github.v3.raw' })
+        .to_return(status: 200, body: license_file)
 
-      allow(Octokit)
-        .to receive(:contents)
-        .with(repo, path: 'README.md', accept: 'application/vnd.github.v3.raw')
-        .and_return(readme_file)
+      stub_request(:get, 'https://api.github.com/repos/benbalter/licensee/contents/README.md')
+        .with(headers: { 'accept' => 'application/vnd.github.v3.raw' })
+        .to_return(status: 200, body: readme_file)
     end
 
     it 'returns the license' do
@@ -119,11 +95,11 @@ RSpec.describe Licensee::Projects::GitHubProject do
   end
 
   context 'when the repo cannot be found' do
-    let(:github_url) { 'https://github.com/benbalter/not-foundsss' }
+    let(:repo) { 'benbalter/not-foundsss' }
 
     before do
-      allow(Octokit)
-        .to receive(:contents).with(anything).and_raise(Octokit::NotFound)
+      stub_request(:get, 'https://api.github.com/repos/benbalter/not-foundsss/contents/')
+        .to_return(status: 404)
     end
 
     it 'raises a RepoNotFound error' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,9 @@ require 'open3'
 require 'tmpdir'
 require 'mustache'
 
+require 'webmock/rspec'
+WebMock.disable_net_connect!
+
 RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.example_status_persistence_file_path = 'spec/examples.txt'
@@ -28,6 +31,10 @@ end
 
 def fixture_path(fixture)
   File.expand_path fixture, fixtures_base
+end
+
+def fixture_contents(fixture)
+  File.read fixture_path(fixture)
 end
 
 def sub_copyright_info(license)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,19 @@ def fixture_contents(fixture)
   File.read fixture_path(fixture)
 end
 
+def fixture_root_files(fixture)
+  Dir["#{fixture_path(fixture)}/*"]
+end
+
+def fixture_root_contents_from_api(fixture)
+  fixture_root_files(fixture).map do |file|
+    {
+      name: File.basename(file),
+      type: 'file'
+    }
+  end.to_json
+end
+
 def sub_copyright_info(license)
   Mustache.render license.content_for_mustache, fullname: 'Ben Balter',
                                                 year:     '2016',


### PR DESCRIPTION
A follow up to https://github.com/benbalter/licensee/pull/251, this PR uses Webmock to stub the API responses from GitHub, rather than stubbing individual Octokit methods, getting us closer to the code, in case the underlying library changes.

**Edit**: I was also able to stub the API requests to test GitHubProject as part of the `project_spec` integration test.

/cc with lots of thanks, @nickcampbell18.