### PR TITLE
allow repos to have . in name

### DIFF
--- a/lib/licensee/projects/github_project.rb
+++ b/lib/licensee/projects/github_project.rb
@@ -12,7 +12,8 @@ module Licensee
     class GitHubProject < Licensee::Projects::Project
       # If there's any trailing data (e.g. `.git`) this pattern will ignore it:
       # we're going to use the API rather than clone the repo.
-      GITHUB_REPO_PATTERN = %r{https://github.com/([^\/]+\/([^\/]+(?=\.git)|[^\/]+)).*}
+      GITHUB_REPO_PATTERN =
+        %r{https://github.com/([^\/]+\/([^\/]+(?=\.git)|[^\/]+)).*}
 
       class RepoNotFound < StandardError; end
 

--- a/lib/licensee/projects/github_project.rb
+++ b/lib/licensee/projects/github_project.rb
@@ -12,7 +12,7 @@ module Licensee
     class GitHubProject < Licensee::Projects::Project
       # If there's any trailing data (e.g. `.git`) this pattern will ignore it:
       # we're going to use the API rather than clone the repo.
-      GITHUB_REPO_PATTERN = %r{https://github.com/([^\/]+\/[^\/\.]+).*}
+      GITHUB_REPO_PATTERN = %r{https://github.com/([^\/]+\/([^\/]+(?=\.git)|[^\/]+)).*}
 
       class RepoNotFound < StandardError; end
 

--- a/spec/bin_spec.rb
+++ b/spec/bin_spec.rb
@@ -61,12 +61,4 @@ RSpec.describe 'command line invocation' do
       expect(stdout).to match('License: MIT License')
     end
   end
-
-  context 'when given a repo URL' do
-    let(:arguments) { 'https://github.com/benbalter/licensee' }
-
-    it "detects the file's license" do
-      expect(stdout).to match('License: MIT License')
-    end
-  end
 end


### PR DESCRIPTION
Recover ability to use `licensee` with repos like `https://github.com/github/choosealicense.com` following #251 (`.git` is still stripped if provided).