### PR TITLE
Add support for matching licenses in Cargo.toml

### DIFF
--- a/lib/licensee/matchers.rb
+++ b/lib/licensee/matchers.rb
@@ -2,6 +2,7 @@ module Licensee
   module Matchers
     autoload :Matcher,   'licensee/matchers/matcher'
     autoload :Cabal,     'licensee/matchers/cabal'
+    autoload :Cargo,     'licensee/matchers/cargo'
     autoload :Copyright, 'licensee/matchers/copyright'
     autoload :Cran,      'licensee/matchers/cran'
     autoload :Dice,      'licensee/matchers/dice'

--- a/lib/licensee/matchers/cargo.rb
+++ b/lib/licensee/matchers/cargo.rb
@@ -1,0 +1,16 @@
+module Licensee
+  module Matchers
+    class Cargo < Licensee::Matchers::Package
+      LICENSE_REGEX = /
+        ^\s*[\'\"]?license[\'\"]?\s*=\s*[\'\"]([a-z\-0-9\._]+)[\'\"]\s*
+      /ix
+
+      private
+
+      def license_property
+        match = @file.content.match LICENSE_REGEX
+        match[1].downcase if match && match[1]
+      end
+    end
+  end
+end

--- a/lib/licensee/project_files/package_manager_file.rb
+++ b/lib/licensee/project_files/package_manager_file.rb
@@ -12,12 +12,14 @@ module Licensee
       FILENAMES_EXTENSIONS = {
         'DESCRIPTION'  => [Matchers::Cran],
         'dist.ini'     => [Matchers::DistZilla],
-        'LICENSE.spdx' => [Matchers::Spdx]
+        'LICENSE.spdx' => [Matchers::Spdx],
+        'Cargo.toml'   => [Matchers::Cargo]
       }.freeze
 
       FILENAMES_SCORES = {
         'package.json' => 1.0,
         'LICENSE.spdx' => 1.0,
+        'Cargo.toml'   => 1.0,
         'DESCRIPTION'  => 0.9,
         'dist.ini'     => 0.8,
         'bower.json'   => 0.75

--- a/spec/licensee/matchers/cargo_matcher_spec.rb
+++ b/spec/licensee/matchers/cargo_matcher_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Licensee::Matchers::Cargo do
+  let(:mit) { Licensee::License.find('mit') }
+  let(:content) { 'license = "MIT"' }
+  let(:file) { Licensee::ProjectFiles::LicenseFile.new(content, 'Cargo.toml') }
+  subject { described_class.new(file) }
+
+  it 'stores the file' do
+    expect(subject.file).to eql(file)
+  end
+
+  it 'has confidence' do
+    expect(subject.confidence).to eql(90)
+  end
+
+  it 'matches' do
+    expect(subject.match).to eql(mit)
+  end
+
+  {
+    'spdx name'          => ['license = "MIT"', 'mit'],
+    'single quotes'      => ["license = 'mit'", 'mit'],
+    'quoted key'         => ["'license' = 'mit'", 'mit'],
+    'double quoted key'  => ['"license"="mit"', 'mit'],
+    'no whitespace'      => ["license='mit'", 'mit'],
+    'leading whitespace' => [" license = 'mit'", 'mit'],
+    'other license'      => ['license = "Foo"', 'other']
+  }.each do |description, license_declaration_and_key|
+    context "with a #{description}" do
+      let(:content) { license_declaration_and_key[0] }
+      let(:license) { Licensee::License.find(license_declaration_and_key[1]) }
+
+      it 'matches' do
+        expect(subject.match).to eql(license)
+      end
+    end
+  end
+
+  context 'no license field' do
+    let(:content) { 'foo = "bar"' }
+
+    it 'returns nil' do
+      expect(subject.match).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Cargo is the package manager for Rust, manifest files are written in toml