### PR TITLE
multiple licenses in Cargo.toml obtains other rather than nil

### DIFF
--- a/lib/licensee/matchers/cargo.rb
+++ b/lib/licensee/matchers/cargo.rb
@@ -2,7 +2,7 @@ module Licensee
   module Matchers
     class Cargo < Licensee::Matchers::Package
       LICENSE_REGEX = /
-        ^\s*[\'\"]?license[\'\"]?\s*=\s*[\'\"]([a-z\-0-9\._]+)[\'\"]\s*
+        ^\s*[\'\"]?license[\'\"]?\s*=\s*[\'\"]([a-z\-0-9\.+\/]+)[\'\"]\s*
       /ix
 
       private

--- a/lib/licensee/matchers/cargo.rb
+++ b/lib/licensee/matchers/cargo.rb
@@ -1,9 +1,9 @@
 module Licensee
   module Matchers
     class Cargo < Licensee::Matchers::Package
-      LICENSE_REGEX = /
+      LICENSE_REGEX = %r{
         ^\s*[\'\"]?license[\'\"]?\s*=\s*[\'\"]([a-z\-0-9\.+\/]+)[\'\"]\s*
-      /ix
+      }ix
 
       private
 

--- a/spec/licensee/matchers/cargo_matcher_spec.rb
+++ b/spec/licensee/matchers/cargo_matcher_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Licensee::Matchers::Cargo do
     'double quoted key'  => ['"license"="mit"', 'mit'],
     'no whitespace'      => ["license='mit'", 'mit'],
     'leading whitespace' => [" license = 'mit'", 'mit'],
-    'other license'      => ['license = "Foo"', 'other']
+    'other license'      => ['license = "Foo"', 'other'],
+    'multiple licenses'  => ['license = "Apache-2.0/MIT"', 'other']
   }.each do |description, license_declaration_and_key|
     context "with a #{description}" do
       let(:content) { license_declaration_and_key[0] }


### PR DESCRIPTION
Analogous to #240

http://doc.crates.io/manifest.html#package-metadata says `/` can separate multiple licenses (unfortunately underspecified in my view; a SPDX license expression instead, as used by NPM, makes it unambiguous whether `OR` or `AND` is intended in multiple license situations).

Also remove `_` which is not used in license ids, add `+` which is.