### PR TITLE
Allow detection of license in elm-package.json

### DIFF
--- a/lib/licensee/project_files/package_manager_file.rb
+++ b/lib/licensee/project_files/package_manager_file.rb
@@ -17,12 +17,13 @@ module Licensee
       }.freeze
 
       FILENAMES_SCORES = {
-        'package.json' => 1.0,
-        'LICENSE.spdx' => 1.0,
-        'Cargo.toml'   => 1.0,
-        'DESCRIPTION'  => 0.9,
-        'dist.ini'     => 0.8,
-        'bower.json'   => 0.75
+        'package.json'     => 1.0,
+        'LICENSE.spdx'     => 1.0,
+        'Cargo.toml'       => 1.0,
+        'DESCRIPTION'      => 0.9,
+        'dist.ini'         => 0.8,
+        'bower.json'       => 0.75,
+        'elm-package.json' => 0.7
       }.freeze
 
       def possible_matchers

--- a/spec/licensee/project_files/package_info_spec.rb
+++ b/spec/licensee/project_files/package_info_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Licensee::ProjectFiles::PackageManagerFile do
       'DESCRIPTION'      => 0.9,
       'dist.ini'         => 0.8,
       'bower.json'       => 0.75,
+      'elm-package.json' => 0.70,
       'README.md'        => 0.0
     }.each do |filename, expected_score|
       context "a file named #{filename}" do


### PR DESCRIPTION
Adds support detecting licenses from the elm package manager https://github.com/elm-lang/elm-package

Uses the `NpmBower` matcher as the format is almost identical, I didn't think it made sense to rename the matcher to `NpmBowerElm` as there are a few other package managers that use json files which would probably be able to use it too and the class name would get kinda ridiculous after a while!

I wasn't sure what the correct score would be, does 0.7 make sense or should it be higher?