### PR TITLE
matchers/cargo: Allow SPDX expressions

### DIFF
--- a/lib/licensee/matchers/cargo.rb
+++ b/lib/licensee/matchers/cargo.rb
@@ -2,7 +2,7 @@ module Licensee
   module Matchers
     class Cargo < Licensee::Matchers::Package
       LICENSE_REGEX = %r{
-        ^\s*[\'\"]?license[\'\"]?\s*=\s*[\'\"]([a-z\-0-9\.+\/]+)[\'\"]\s*
+        ^\s*[\'\"]?license[\'\"]?\s*=\s*[\'\"]([a-z\-0-9\. +()\/]+)[\'\"]\s*
       }ix
 
       private

--- a/spec/licensee/matchers/cargo_matcher_spec.rb
+++ b/spec/licensee/matchers/cargo_matcher_spec.rb
@@ -17,14 +17,16 @@ RSpec.describe Licensee::Matchers::Cargo do
   end
 
   {
-    'spdx name'          => ['license = "MIT"', 'mit'],
-    'single quotes'      => ["license = 'mit'", 'mit'],
-    'quoted key'         => ["'license' = 'mit'", 'mit'],
-    'double quoted key'  => ['"license"="mit"', 'mit'],
-    'no whitespace'      => ["license='mit'", 'mit'],
-    'leading whitespace' => [" license = 'mit'", 'mit'],
-    'other license'      => ['license = "Foo"', 'other'],
-    'multiple licenses'  => ['license = "Apache-2.0/MIT"', 'other']
+    'spdx name'                => ['license = "MIT"', 'mit'],
+    'single quotes'            => ["license = 'mit'", 'mit'],
+    'quoted key'               => ["'license' = 'mit'", 'mit'],
+    'double quoted key'        => ['"license"="mit"', 'mit'],
+    'no whitespace'            => ["license='mit'", 'mit'],
+    'leading whitespace'       => [" license = 'mit'", 'mit'],
+    'other license'            => ['license = "Foo"', 'other'],
+    'multiple licenses /'      => ['license = "Apache-2.0/MIT"', 'other'],
+    'multiple licenses OR'     => ['license = "Apache-2.0 OR MIT"', 'other'],
+    'multiple licenses parens' => ['license = "(Apache-2.0 OR MIT)"', 'other']
   }.each do |description, license_declaration_and_key|
     context "with a #{description}" do
       let(:content) { license_declaration_and_key[0] }


### PR DESCRIPTION
Using a regex that is similar to the one in `lib/licensee/matchers/spdx.rb` in allowing spaces and parens.  Parens aren't currently supported by Cargo's crates.io backing (see [here][1] and rust-lang-nursery/license-exprs#3), but that's hopefully a temporary limitation.  And Cargo/crates.io already supports OR forms (rust-lang/cargo#4920).

Ideally licensee would return the full license expression in these cases instead of `other` (#244).  But since that conversion is happening outside the matcher, this commit isn't making that any worse (although it means this test isn't quite a unit test).

[1]: https://github.com/rust-lang/cargo/pull/4898/commits/c89dd6452ce71765eb47c675d32ecc3834f78691
  