### PR TITLE
Allow detection of license in haxelib.json

### DIFF
--- a/lib/licensee/project_files/package_manager_file.rb
+++ b/lib/licensee/project_files/package_manager_file.rb
@@ -23,7 +23,8 @@ module Licensee
         'DESCRIPTION'      => 0.9,
         'dist.ini'         => 0.8,
         'bower.json'       => 0.75,
-        'elm-package.json' => 0.7
+        'elm-package.json' => 0.7,
+        'haxelib.json'     => 0.7
       }.freeze
 
       def possible_matchers

--- a/spec/licensee/project_files/package_info_spec.rb
+++ b/spec/licensee/project_files/package_info_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Licensee::ProjectFiles::PackageManagerFile do
       'dist.ini'         => 0.8,
       'bower.json'       => 0.75,
       'elm-package.json' => 0.70,
+      'haxelib.json'     => 0.70,
       'README.md'        => 0.0
     }.each do |filename, expected_score|
       context "a file named #{filename}" do


### PR DESCRIPTION
Adds support detecting licenses from the Haxe package manager, docs here: https://haxe.org/manual/haxelib-json.html

Very similar to https://github.com/benbalter/licensee/pull/259