### PR TITLE
Add support for detecting licenses in Rdoc-formatted READMEs

### DIFF
--- a/lib/licensee/project_files/readme_file.rb
+++ b/lib/licensee/project_files/readme_file.rb
@@ -1,21 +1,30 @@
 module Licensee
   module ProjectFiles
     class ReadmeFile < Licensee::ProjectFiles::LicenseFile
+      EXTENSIONS = %w[md markdown mdown txt rdoc].freeze
       SCORES = {
-        /\AREADME\z/i                          => 1.0,
-        /\AREADME\.(md|markdown|mdown|txt)\z/i => 0.9
+        /\AREADME\z/i                                       => 1.0,
+        /\AREADME\.(#{Regexp.union(EXTENSIONS).source})\z/i => 0.9
       }.freeze
 
+      TITLE_REGEX = /licen[sc]e:?/i
+      UNDERLINE_REGEX = /\n[-=]+/m
       CONTENT_REGEX = /^
-          (?:\#+\sLicen[sc]e     # Start of hashes-based license header
-             |
-             Licen[sc]e\n[-=]+)$ # Start of underlined license header
-          (.*?)                  # License content
-          (?=^(?:\#+             # Next hashes-based header
-                 |
-                 [^\n]+\n[-=]+)  # Next of underlined header
-             |
-             \z)                 # End of file
+          (?:                                # Header lookbehind
+            [\#=]+\s#{TITLE_REGEX}           # Start of hashes or rdoc header
+          |
+            #{TITLE_REGEX}#{UNDERLINE_REGEX} # Start of underlined header
+          )$
+          (.*?)                              # License content
+          (?=^                               # Header or end of file lookahead
+            (?:
+              [\#=]+                         # Next hash or rdoc header
+            |
+              [^\n]+#{UNDERLINE_REGEX}       # Next of underlined header
+            )
+          |
+            \z                               # End of file
+          )
         /mix
 
       def possible_matchers

--- a/spec/licensee/project_files/readme_file_spec.rb
+++ b/spec/licensee/project_files/readme_file_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Licensee::ProjectFiles::ReadmeFile do
       'README.md'    => 0.9,
       'readme.txt'   => 0.9,
       'readme.mdown' => 0.9,
+      'readme.rdoc'  => 0.9,
       'LICENSE'      => 0.0
     }.each do |filename, expected_score|
       context "with a file named #{filename}" do
@@ -92,6 +93,22 @@ RSpec.describe Licensee::ProjectFiles::ReadmeFile do
 
     context 'with trailing content that has a hashes-based header' do
       let(:content) { "# License\n\nhello world\n\n# Contributing" }
+
+      it 'returns the license' do
+        expect(license).to eql('hello world')
+      end
+    end
+
+    context 'With a trailing colon' do
+      let(:content) { "## License:\n\nhello world" }
+
+      it 'returns the license' do
+        expect(license).to eql('hello world')
+      end
+    end
+
+    context 'Rdoc' do
+      let(:content) { "== License:\n\nhello world" }
 
       it 'returns the license' do
         expect(license).to eql('hello world')


### PR DESCRIPTION
Also:

* A small refactor of our README regex to make it easier to read/understand
* Support for trailing colons in license headers

Example:

```
➜  licensee git:(rdoc-readme-support) ✗ script/git-repo https://github.com/seattlerb/minitest
License: MIT License
Matched files: ["README.rdoc"]
README.rdoc:
  Content hash: 44ae3474f0d3d037984c7e8d52adc4d3eb39a200
  Attribution: Copyright (c) Ryan Davis, seattle.rb
  Confidence: 90.00%
  Matcher: Licensee::Matchers::Reference
  License: MIT License
  Closest licenses:
    * MIT similarity: 97.83%
```

/cc @parkr