### PR TITLE
Normalize quotes in license text

### DIFF
--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -16,7 +16,7 @@ module Licensee
     # A set of each word in the license, without duplicates
     def wordset
       @wordset ||= if content_normalized
-        content_normalized.scan(/[\w']+/).to_set
+        content_normalized.scan(/(?:\w(?:'s|(?<=s)')?)+/).to_set
       end
     end
 
@@ -79,6 +79,7 @@ module Licensee
         string = strip_all_rights_reserved(string)
         string, _partition, _instructions = string.partition(END_OF_TERMS_REGEX)
         string = strip_markup(string)
+        string = normalize_quotes(string)
         strip_whitespace(string)
       end
 
@@ -163,6 +164,13 @@ module Licensee
 
     def strip(string, regex)
       string.gsub(regex, ' ').squeeze(' ').strip
+    end
+
+    # Replace all single quotes with double quotes
+    # Single versus double quotes don't alter the meaning, and it's easier to
+    # strip double quotes if we still want to allow possessives
+    def normalize_quotes(string)
+      string.gsub(/\s'([\w -]+)'/, ' "\1"')
     end
   end
 end

--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -170,7 +170,7 @@ module Licensee
     # Single versus double quotes don't alter the meaning, and it's easier to
     # strip double quotes if we still want to allow possessives
     def normalize_quotes(string)
-      string.gsub(/\s'([\w -]+)'/, ' "\1"')
+      string.gsub(/\s'([\w -]*?\w)'/, ' "\1"')
     end
   end
 end


### PR DESCRIPTION
I noticed that some (older) versions of the MIT license use single quotes around phrases like `'as is'`, while other (more modern) versions use double quotes (`"as is"`). 

This PR normalizes all single quotes to double quotes prior to comparison, and makes the wordset creation for the dice matcher slightly more possessive aware, so that possessives (which can be legally significant) are captured, but other quotes are not.

### Before

```
➜  licensee git:(master) script/git-repo https://github.com/mojombo/god --license mit
License: Other
Matched files: ["LICENSE", "README.md"]
LICENSE:
  Content hash: 44ae3474f0d3d037984c7e8d52adc4d3eb39a200
  Attribution: Copyright (c) 2007 Tom Preston-Werner
  License: Other
  Closest licenses:
    * MIT similarity: 97.83%
README.md:
  Content hash: 0d97397622a0b54f1f865ebcd3b1810a981b8c57
  License: Other
Comparing to MIT License:
  Input length: 1019
  License length: 1019
  Similarity: 97.83%
diff --git a/LICENSE b/LICENSE
index ce3f035..bbc35b2 100644
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,11 @@
permission is hereby granted, free of charge, to any person obtaining a copy of
this software and associated documentation files the [-"software"-]{+'software'+} , to deal in the
software without restriction, including without limitation the rights to use,
copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
software, and to permit persons to whom the software is furnished to do so,
subject to the following conditions: the above copyright notice and this
permission notice shall be included in all copies or substantial portions of the
software. the software is provided [-"as is",-]{+'as is',+} without warranty of any kind,
express or implied, including but not limited to the warranties of
merchantability, fitness for a particular purpose and noninfringement. in no
event shall the authors or copyright holders be liable for any claim, damages or
```

### After

```
➜  licensee git:(normalize-quotes) script/git-repo https://github.com/mojombo/god --license mit
License: Other
Matched files: ["LICENSE", "README.md"]
LICENSE:
  Content hash: 46cdc03462b9af57968df67b450cc4372ac41f53
  Attribution: Copyright (c) 2007 Tom Preston-Werner
  Confidence: 100.00%
  Matcher: Licensee::Matchers::Exact
  License: MIT License
README.md:
  Content hash: 0d97397622a0b54f1f865ebcd3b1810a981b8c57
  License: Other
Comparing to MIT License:
  Input length: 1019
  License length: 1019
  Similarity: 100.00%
  Exact match!
```