### PR TITLE
autoload octokit as it won't be used unless project is remote repo

### DIFF
--- a/lib/licensee/projects/github_project.rb
+++ b/lib/licensee/projects/github_project.rb
@@ -5,7 +5,7 @@
 # Only the root directory of a repository will be scanned because every
 # `#load_file(..)` call incurs a separate API request.
 
-require 'octokit'
+autoload :Octokit, 'octokit'
 
 module Licensee
   module Projects


### PR DESCRIPTION
Which will never be the case for some deployments. Fixes #268 

Seems to work, see below. I'm not of a good way to write a test since whether it is loaded would depend on whether any test accessing a remote repo had been run.

```
$ irb
irb(main):001:0> require 'licensee'
=> true
irb(main):002:0> defined?(Octokit)
=> nil
irb(main):003:0> Licensee.project('.')
=> #<Licensee::Projects::GitProject:0x00007fea220e5c90 @repository=#<Rugged::Repository:70321785220620 {path: "/Users/mlinksva/G/licensee/.git/"}>, @revision=nil, @detect_packages=false, @detect_readme=false>
irb(main):004:0> defined?(Octokit)
=> nil
irb(main):005:0> Licensee.project('https://github.com/benbalter/licensee')
=> #<Licensee::Projects::GitHubProject:0x00007fea2240e7a0 @repo="benbalter/licensee", @detect_packages=false, @detect_readme=false>
irb(main):006:0> defined?(Octokit)
=> "constant"
```