### PR TITLE
output SPDX ID instead of lowercased key in json matched_license field

### DIFF
--- a/lib/licensee/project_files/project_file.rb
+++ b/lib/licensee/project_files/project_file.rb
@@ -67,7 +67,7 @@ module Licensee
       alias path filename
 
       def matched_license
-        license.key if license
+        license.spdx_id if license
       end
 
       # Is this file a COPYRIGHT file with only a copyright statement?

--- a/spec/fixtures/detect.json
+++ b/spec/fixtures/detect.json
@@ -94,7 +94,7 @@
         "name": "exact",
         "confidence": 100
       },
-      "matched_license": "mit"
+      "matched_license": "MIT"
     },
     {
       "filename": "licensee.gemspec",
@@ -105,7 +105,7 @@
         "name": "gemspec",
         "confidence": 90
       },
-      "matched_license": "mit"
+      "matched_license": "MIT"
     }
   ]
 }

--- a/spec/licensee/project_files/project_file_spec.rb
+++ b/spec/licensee/project_files/project_file_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Licensee::ProjectFiles::ProjectFile do
           name:       :exact,
           confidence: 100
         },
-        matched_license:    'mit'
+        matched_license:    'MIT'
       }
     end
 


### PR DESCRIPTION
Fixes #282 (in case we wish to go that way)