### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,12 @@ On Windows, the last line needs to include the Ruby interpreter:
 
     bundle exec ruby bin\licensee
 
+In a Docker Debian Stretch container, minimum dependencies are:
+
+```
+apt-get install -y ruby bundler cmake pkg-config git libssl-dev
+```
+
 ## Documentation
 
 See [the docs folder](/docs) for more information. You may be interested in:


### PR DESCRIPTION
Add minimum dependencies for a Docker Debian Stretch container, in order to let users test/use the latest licensee sources without installing all of them locally. E.g.:

```
docker run --rm -it debian:stretch-slim bash -c "\
  apt-get update && \
  apt-get install -y ruby bundler cmake pkg-config git libssl-dev && \
  git clone https://github.com/benbalter/licensee/ && \
  cd licensee && \
  bundle install --path vendor/bundle && \
sh"
```