### PR TITLE
Normalize http: to https:

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ Metrics/BlockLength:
 Style/Documentation:
   Enabled: false
 
-Lint/EndAlignment:
+Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
   AutoCorrect: true
 

--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -82,6 +82,7 @@ module Licensee
         string, _partition, _instructions = string.partition(END_OF_TERMS_REGEX)
         string = strip_markup(string)
         string = normalize_quotes(string)
+        string = normalize_https(string)
         strip_whitespace(string)
       end
 
@@ -177,6 +178,10 @@ module Licensee
     # strip double quotes if we still want to allow possessives
     def normalize_quotes(string)
       string.gsub(/\s'([\w -]*?\w)'/, ' "\1"')
+    end
+
+    def normalize_https(string)
+      string.gsub(/http:/, 'https:')
     end
   end
 end

--- a/spec/licensee/content_helper_spec.rb
+++ b/spec/licensee/content_helper_spec.rb
@@ -103,6 +103,12 @@ LICENSE
       expect(license.content_normalized).to_not include('* *')
     end
 
+    it 'normalizes http: to https:' do
+      license = Licensee::License.find('mpl-2.0')
+      expect(license.content).to include('http:')
+      expect(license.content_normalized).to_not include('http:')
+    end
+
     it 'wraps' do
       lines = mit.content_normalized(wrap: 40).split("\n")
       expect(lines.first.length).to be <= 40


### PR DESCRIPTION
Reflectng consensus in https://github.com/spdx/license-list-XML/issues/633

Also allowing updating of some vendored licenses to https reflecting what some license stewards have done eg https://github.com/github/choosealicense.com/pull/543#issue-147444584 without any risk of false negatives.