### PR TITLE
Update vendor/choosealicense for UPL 1.0

### DIFF
--- a/vendor/choosealicense.com/_licenses/cc-by-4.0.txt
+++ b/vendor/choosealicense.com/_licenses/cc-by-4.0.txt
@@ -1,5 +1,5 @@
 ---
-title: Creative Commons Attribution 4.0
+title: Creative Commons Attribution 4.0 International
 spdx-id: CC-BY-4.0
 source: https://creativecommons.org/licenses/by/4.0/legalcode.txt
 

--- a/vendor/choosealicense.com/_licenses/cc-by-sa-4.0.txt
+++ b/vendor/choosealicense.com/_licenses/cc-by-sa-4.0.txt
@@ -1,5 +1,5 @@
 ---
-title: Creative Commons Attribution Share Alike 4.0
+title: Creative Commons Attribution Share Alike 4.0 International
 spdx-id: CC-BY-SA-4.0
 source: https://creativecommons.org/licenses/by-sa/4.0/legalcode.txt
 

--- a/vendor/choosealicense.com/_licenses/upl-1.0.txt
+++ b/vendor/choosealicense.com/_licenses/upl-1.0.txt
@@ -1,0 +1,67 @@
+---
+title: Universal Permissive License v1.0
+spdx-id: UPL-1.0
+source: https://oss.oracle.com/licenses/upl/
+
+description: A permissive, OSI and FSF approved, GPL compatible license, expressly allowing attribution with just a copyright notice and a short form link rather than the full text of the license.  Includes an express grant of patent rights.  Licensed works and modifications may be distributed under different terms and without source code, and the patent grant may also optionally be expanded to larger works to permit use as a contributor license agreement.
+
+how: Insert the license or a link to it along with a copyright notice into your source file(s), and/or create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license and your copyright notice into the file.
+
+note: It is recommended to add a link to the license and copyright notice at the top of each source file, example text can be found at https://oss.oracle.com/licenses/upl/.
+
+using:
+  - WebLogic Kubernetes Operator: https://github.com/oracle/weblogic-kubernetes-operator/blob/master/LICENSE
+  - Oracle Product Images for Docker: https://github.com/oracle/docker-images/blob/master/LICENSE
+  - Oracle Product Boxes for Vagrant: https://github.com/oracle/vagrant-boxes/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - modifications
+  - distribution
+  - patent-use
+  - private-use
+
+conditions:
+  - include-copyright
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+Copyright (c) [year] [fullname]
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any
+person obtaining a copy of this software, associate documentation and/or data
+(collectively the "Software"), free of charge and under any and all copyright
+rights in the Software, and any and all patent rights owned or freely
+licensable by each licensor hereunder covering either (i) the unmodified
+Software as contributed to or provided by such licensor, or (ii) the Larger
+Works (as defined below), to deal in both
+
+(a) the Software, and
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+one is included with the Software (each a “Larger Work” to which the Software
+is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create
+derivative works of, display, perform, and distribute the Software and make,
+use, sell, offer for sale, import, export, have made, and have sold the
+Software and the Larger Work(s), and to sublicense the foregoing rights on
+either these or other terms.
+
+This license is subject to the following condition:
+The above copyright notice and either this complete permission notice or at
+a minimum a reference to the UPL must be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Updated the vendor files for ChooseALicense.com to get updated versions
of CC-BY licenses and bring in the new UPL 1.0 license.