### PR TITLE
NONE and NOASSERTION for 'no-license' and 'other'

### DIFF
--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -117,6 +117,12 @@ module Licensee
       @meta ||= LicenseMeta.from_yaml(yaml)
     end
 
+    def spdx_id
+      return meta.spdx_id if meta.spdx_id
+      return 'NOASSERTION' if key == 'other'
+      return 'NONE' if key == 'no-license'
+    end
+
     # Returns the human-readable license name
     def name
       title ? title : key.capitalize

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Licensee::License do
   let(:cc_by) { described_class.find('cc-by-4.0') }
   let(:unlicense) { described_class.find('unlicense') }
   let(:other) { described_class.find('other') }
+  let(:no_license) { described_class.find('no-license') }
   let(:gpl) { described_class.find('gpl-3.0') }
   let(:lgpl) { described_class.find('lgpl-3.0') }
   let(:content_hash) { '46cdc03462b9af57968df67b450cc4372ac41f53' }
@@ -166,6 +167,11 @@ RSpec.describe Licensee::License do
 
   it 'exposes the SPDX ID' do
     expect(gpl.spdx_id).to eql('GPL-3.0')
+  end
+
+  it 'exposes special SPDX ID for pseudo licenses' do
+    expect(other.spdx_id).to eql('NOASSERTION')
+    expect(no_license.spdx_id).to eql('NONE')
   end
 
   context '#other?' do


### PR DESCRIPTION
Based on https://spdx.org/spdx-specification-21-web-version#h.ihv636

Fixes #296 