### PR TITLE
Output internal 'key' if no SPDX ID (for pseudo licenses)

### DIFF
--- a/lib/licensee/commands/detect.rb
+++ b/lib/licensee/commands/detect.rb
@@ -21,9 +21,9 @@ class LicenseeCLI < Thor
 
     rows = []
     rows << if project.license
-              ['License:', project.license.spdx_id]
+              ['License:', project.license.spdx_id_or_key]
             elsif !project.licenses.empty?
-              ['Licenses:', project.licenses.map(&:spdx_id)]
+              ['Licenses:', project.licenses.map(&:spdx_id_or_key)]
             else
               ['License:', set_color('None', :red)]
             end
@@ -77,7 +77,7 @@ class LicenseeCLI < Thor
   def humanize(value, type = nil)
     case type
     when :license
-      value.spdx_id
+      value.spdx_id_or_key
     when :matcher
       value.class
     when :confidence

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -228,6 +228,10 @@ module Licensee
       end
     end
 
+    def spdx_id_or_key
+      spdx_id || key
+    end
+
     private
 
     # Raw content of license file, including YAML front matter

--- a/lib/licensee/project_files/project_file.rb
+++ b/lib/licensee/project_files/project_file.rb
@@ -67,7 +67,7 @@ module Licensee
       alias path filename
 
       def matched_license
-        license.spdx_id if license
+        license.spdx_id_or_key if license
       end
 
       # Is this file a COPYRIGHT file with only a copyright statement?


### PR DESCRIPTION
I prefer #297 to this, but making this PR to illustrate the alternative.

Fixes #296 