### PR TITLE
no attribution from instance license file if matching license file not templated

### DIFF
--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -54,6 +54,7 @@ module Licensee
 
       def attribution
         @attribution ||= begin
+          return unless license.content =~ /\[fullname\]/
           matches = Matchers::Copyright::REGEX
                     .match(content_without_title_and_version)
           matches[0] if matches

--- a/spec/licensee/project_files/license_file_spec.rb
+++ b/spec/licensee/project_files/license_file_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Licensee::ProjectFiles::LicenseFile do
   let(:filename) { 'LICENSE.txt' }
+  let(:gpl) { Licensee::License.find('gpl-3.0') }
   let(:mit) { Licensee::License.find('mit') }
   let(:content) { sub_copyright_info(mit) }
   let(:content_hash) { '46cdc03462b9af57968df67b450cc4372ac41f53' }
@@ -22,6 +23,14 @@ RSpec.describe Licensee::ProjectFiles::LicenseFile do
     let(:content) { "\x91License\x93".force_encoding('windows-1251') }
 
     it "doesn't blow up " do
+      expect(subject.attribution).to be_nil
+    end
+  end
+
+  context 'with a non-templated license' do
+    let(:content) { sub_copyright_info(gpl) }
+
+    it "doesn't match" do
       expect(subject.attribution).to be_nil
     end
   end
@@ -215,7 +224,6 @@ Creative Commons Attribution-NonCommercial 4.0
   end
 
   context 'GPL' do
-    let(:gpl) { Licensee::License.find('gpl-3.0') }
     let(:content) { sub_copyright_info(gpl) }
 
     it 'knows its GPL' do


### PR DESCRIPTION
Fixes #299 