### PR TITLE
clarify that printed closest licenses are non-matches

### DIFF
--- a/lib/licensee/commands/detect.rb
+++ b/lib/licensee/commands/detect.rb
@@ -51,7 +51,7 @@ class LicenseeCLI < Thor
 
       licenses = licenses_by_similiarity(matched_file)
       next if licenses.empty?
-      say '  Closest licenses:'
+      say '  Closest non-matching licenses:'
       rows = licenses[0...3].map do |license, similarity|
         spdx_id = license.meta['spdx-id']
         percent = Licensee::ContentHelper.format_percent(similarity)


### PR DESCRIPTION
Motivated by someone taking closest license as a "best guess", which is not what licensee is trying to communicate: https://github.com/benbalter/licensee/issues/306#issuecomment-397118535

There's probably an even better way to say this, just taking a stab.