### PR TITLE
remove use of bower to vendor choosealicense.com

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory": "vendor"
-}

--- a/.gitignore
+++ b/.gitignore
@@ -15,13 +15,3 @@ vendor/eventEmitter
 vendor/eventie
 vendor/imagesloaded
 vendor/ev-emitter
-vendor/choosealicense.com/_sass
-vendor/choosealicense.com/_includes
-vendor/choosealicense.com/_layouts
-vendor/choosealicense.com/assets
-vendor/choosealicense.com/script
-vendor/choosealicense.com/*.*
-vendor/choosealicense.com/CNAME
-vendor/choosealicense.com/Gemfile
-vendor/choosealicense.com/Rakefile
-vendor/choosealicense.com/spec

--- a/script/vendor-licenses
+++ b/script/vendor-licenses
@@ -1,4 +1,6 @@
 #!/bin/sh
 
-rm -Rf vendor/choosealicense.com
-bower install github/choosealicense.com#gh-pages
+VENDOR_DIR=vendor/choosealicense.com
+rm -Rf $VENDOR_DIR
+mkdir -p $VENDOR_DIR
+curl -L https://api.github.com/repos/github/choosealicense.com/tarball |tar xf - --include='*/_data' --include='*/_licenses' --strip-components=1 -C $VENDOR_DIR


### PR DESCRIPTION
Easy enough to replace with just `curl` and `tar`.

Unimportant, just a thought upon reading @ale5000-git's comment at https://github.com/benbalter/licensee/issues/313#issuecomment-405340475 that bower emits a deprecation notice.