### PR TITLE
More robust quoted string normalization

### DIFF
--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -11,8 +11,10 @@ module Licensee
     WHITESPACE_REGEX = /\s+/
     MARKDOWN_HEADING_REGEX = /\A\s*#+/
     VERSION_REGEX = /\Aversion.*$/i
-    MARKUP_REGEX = /[#_*=~\[\]()`|>]+/
+    MARKUP_REGEX = /[#_*=~\[\]()|>]+/
     DEVELOPED_BY_REGEX = /\Adeveloped by:.*?\n\n/im
+    QUOTE_BEGIN_REGEX = /[`'"‘“]/
+    QUOTE_END_REGEX = /['"’”]/
 
     # A set of each word in the license, without duplicates
     def wordset
@@ -173,11 +175,12 @@ module Licensee
       string.gsub(regex, ' ').squeeze(' ').strip
     end
 
-    # Replace all single quotes with double quotes
+    # Replace all enclosing quotes with double quotes
     # Single versus double quotes don't alter the meaning, and it's easier to
     # strip double quotes if we still want to allow possessives
     def normalize_quotes(string)
-      string.gsub(/\s'([\w -]*?\w)'/, ' "\1"')
+      string.gsub(/#{QUOTE_BEGIN_REGEX}+([\w -]*?\w)#{QUOTE_END_REGEX}+/,
+                  '"\1"')
     end
 
     def normalize_https(string)

--- a/spec/licensee/matchers/dice_matcher_spec.rb
+++ b/spec/licensee/matchers/dice_matcher_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe Licensee::Matchers::Dice do
 
   it 'sorts licenses by similarity' do
     expect(subject.licenses_by_similiarity[0]).to eql([gpl, 100.0])
-    expect(subject.licenses_by_similiarity[1]).to eql([agpl, 95.73361082206036])
+    expect(subject.licenses_by_similiarity[1]).to eql([agpl, 95.78344612181155])
   end
 
   it 'returns a list of licenses above the confidence threshold' do
     expect(subject.licenses_by_similiarity[0]).to eql([gpl, 100.0])
-    expect(subject.licenses_by_similiarity[1]).to eql([agpl, 95.73361082206036])
+    expect(subject.licenses_by_similiarity[1]).to eql([agpl, 95.78344612181155])
   end
 
   it 'returns the match confidence' do


### PR DESCRIPTION
- allow quote to begin line
- allow mutliple quote characters eg ''
- allow various appropriate begin/end quote characters

Noticed at https://github.com/benbalter/licensee/issues/323#issuecomment-414081486

Also seems to align with other [guidelines on license matching](https://spdx.org/spdx-license-list/matching-guidelines):

> 5.1.3 Guideline:  Quotes  Any variation of quotations (single, double, curly, etc.) should be considered equivalent.