### PR TITLE
Normalize numbered and bulleted lists

### DIFF
--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -11,7 +11,7 @@ module Licensee
     WHITESPACE_REGEX = /\s+/
     MARKDOWN_HEADING_REGEX = /\A\s*#+/
     VERSION_REGEX = /\Aversion.*$/i
-    MARKUP_REGEX = /[#_*=~\[\]()|>]+/
+    MARKUP_REGEX = /[#_*=~\[\]()`|>]+/
     DEVELOPED_BY_REGEX = /\Adeveloped by:.*?\n\n/im
     QUOTE_BEGIN_REGEX = /[`'"‘“]/
     QUOTE_END_REGEX = /['"’”]/
@@ -83,9 +83,9 @@ module Licensee
         string = strip_developed_by(string)
         string, _partition, _instructions = string.partition(END_OF_TERMS_REGEX)
         string = normalize_lists(string)
-        string = strip_markup(string)
         string = normalize_quotes(string)
         string = normalize_https(string)
+        string = strip_markup(string)
         strip_whitespace(string)
       end
 

--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -80,6 +80,7 @@ module Licensee
         string = strip_all_rights_reserved(string)
         string = strip_developed_by(string)
         string, _partition, _instructions = string.partition(END_OF_TERMS_REGEX)
+        string = normalize_lists(string)
         string = strip_markup(string)
         string = normalize_quotes(string)
         string = normalize_https(string)
@@ -182,6 +183,10 @@ module Licensee
 
     def normalize_https(string)
       string.gsub(/http:/, 'https:')
+    end
+
+    def normalize_lists(string)
+      string.gsub(/^\s*(\d\.|\*)/, '-')
     end
   end
 end

--- a/spec/fixtures/bsd-3-lists/LICENSE.BULLETS
+++ b/spec/fixtures/bsd-3-lists/LICENSE.BULLETS
@@ -1,0 +1,27 @@
+Copyright (c) 2018, Ben Balter
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/spec/fixtures/bsd-3-lists/LICENSE.NUMBERS
+++ b/spec/fixtures/bsd-3-lists/LICENSE.NUMBERS
@@ -1,0 +1,27 @@
+Copyright (c) 2018, Ben Balter
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -186,6 +186,15 @@ RSpec.describe 'integration test' do
             expect(subject.license).to eql(license)
           end
         end
+
+        context 'BSD-3-Clause numbered and bulleted' do
+          let(:license) { Licensee::License.find('bsd-3-clause') }
+          let(:fixture) { 'bsd-3-lists' }
+
+          it 'determines the project is BSD-3-Clause' do
+            expect(subject.license).to eql(license)
+          end
+        end
       end
 
       context 'with the license file stubbed' do

--- a/spec/licensee/matchers/dice_matcher_spec.rb
+++ b/spec/licensee/matchers/dice_matcher_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe Licensee::Matchers::Dice do
 
   it 'sorts licenses by similarity' do
     expect(subject.licenses_by_similiarity[0]).to eql([gpl, 100.0])
-    expect(subject.licenses_by_similiarity[1]).to eql([agpl, 95.71577847439916])
+    expect(subject.licenses_by_similiarity[1]).to eql([agpl, 95.76581285938317])
   end
 
   it 'returns a list of licenses above the confidence threshold' do
     expect(subject.licenses_by_similiarity[0]).to eql([gpl, 100.0])
-    expect(subject.licenses_by_similiarity[1]).to eql([agpl, 95.71577847439916])
+    expect(subject.licenses_by_similiarity[1]).to eql([agpl, 95.76581285938317])
   end
 
   it 'returns the match confidence' do

--- a/spec/licensee/matchers/dice_matcher_spec.rb
+++ b/spec/licensee/matchers/dice_matcher_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe Licensee::Matchers::Dice do
 
   it 'sorts licenses by similarity' do
     expect(subject.licenses_by_similiarity[0]).to eql([gpl, 100.0])
-    expect(subject.licenses_by_similiarity[1]).to eql([agpl, 95.73361082206036])
+    expect(subject.licenses_by_similiarity[1]).to eql([agpl, 95.71577847439916])
   end
 
   it 'returns a list of licenses above the confidence threshold' do
     expect(subject.licenses_by_similiarity[0]).to eql([gpl, 100.0])
-    expect(subject.licenses_by_similiarity[1]).to eql([agpl, 95.73361082206036])
+    expect(subject.licenses_by_similiarity[1]).to eql([agpl, 95.71577847439916])
   end
 
   it 'returns the match confidence' do


### PR DESCRIPTION
Some licenses in the wild have numbered or bulleted lists, and it [can matter](https://github.com/github/choosealicense.com/pull/604) when detecting shorter ones.

Also seems to align with other [guidelines on license matching](https://spdx.org/spdx-license-list/matching-guidelines):

> 7. Bullets and Numbering
> 
> 7.1 Purpose:  To avoid the possibility of a non-match due to the otherwise same license using bullets instead of numbers, number instead of letter, or no bullets instead of bullet, etc., for a list of clauses.
> 
> 7.1.1 Guideline:  Where a line starts with a bullet, number, letter, or some form of a list item (determined where list item is followed by a space, then the text of the sentence), ignore the list item for matching purposes. Templates do not include markup for this guideline.