### PR TITLE
Markdown headings can have trailing hashes

### DIFF
--- a/lib/licensee/project_files/readme_file.rb
+++ b/lib/licensee/project_files/readme_file.rb
@@ -11,7 +11,7 @@ module Licensee
       UNDERLINE_REGEX = /\n[-=]+/m
       CONTENT_REGEX = /^
           (?:                                # Header lookbehind
-            [\#=]+\s#{TITLE_REGEX}           # Start of hashes or rdoc header
+            [\#=]+\s#{TITLE_REGEX}\s*[\#=]*  # Start of hashes or rdoc header
           |
             #{TITLE_REGEX}#{UNDERLINE_REGEX} # Start of underlined header
           )$

--- a/spec/licensee/project_files/readme_file_spec.rb
+++ b/spec/licensee/project_files/readme_file_spec.rb
@@ -107,6 +107,14 @@ RSpec.describe Licensee::ProjectFiles::ReadmeFile do
       end
     end
 
+    context 'With trailing hashes' do
+      let(:content) { "## License ##\n\nhello world" }
+
+      it 'returns the license' do
+        expect(license).to eql('hello world')
+      end
+    end
+
     context 'Rdoc' do
       let(:content) { "== License:\n\nhello world" }
 


### PR DESCRIPTION
https://daringfireball.net/projects/markdown/syntax#header

May as well allow trailing =s as well though
https://ruby.github.io/rdoc/RDoc/Markup.html#class-RDoc::Markup-label-Headers
doesn't mention, I've seen in the wild and even added to text
documents myself when forgetting that I'm not editing mediawiki
markup.