### PR TITLE
Nominally support README.rst

### DIFF
--- a/lib/licensee/project_files/readme_file.rb
+++ b/lib/licensee/project_files/readme_file.rb
@@ -1,7 +1,7 @@
 module Licensee
   module ProjectFiles
     class ReadmeFile < Licensee::ProjectFiles::LicenseFile
-      EXTENSIONS = %w[md markdown mdown txt rdoc].freeze
+      EXTENSIONS = %w[md markdown mdown txt rdoc rst].freeze
       SCORES = {
         /\AREADME\z/i                                       => 1.0,
         /\AREADME\.(#{Regexp.union(EXTENSIONS).source})\z/i => 0.9

--- a/spec/licensee/project_files/readme_file_spec.rb
+++ b/spec/licensee/project_files/readme_file_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Licensee::ProjectFiles::ReadmeFile do
       'readme.txt'   => 0.9,
       'readme.mdown' => 0.9,
       'readme.rdoc'  => 0.9,
+      'readme.rst'   => 0.9,
       'LICENSE'      => 0.0
     }.each do |filename, expected_score|
       context "with a file named #{filename}" do


### PR DESCRIPTION
Fixes #310 

rst does support additional underline heading characters that md does not, but `-=` seem by far the most common, so not bothering to add more for this nominal support.

Some files https://github.com/search?q=filename%3AREADME.rst+license