### PR TITLE
Return human readable name for pseudo licenses

### DIFF
--- a/lib/licensee/commands/detect.rb
+++ b/lib/licensee/commands/detect.rb
@@ -40,8 +40,10 @@ class LicenseeCLI < Thor
 
       MATCHED_FILE_METHODS.each do |method|
         next unless matched_file.respond_to? method
+
         value = matched_file.public_send method
         next if value.nil?
+
         rows << [humanize(method, :method), humanize(value, method)]
       end
       print_table rows, indent: 2
@@ -51,6 +53,7 @@ class LicenseeCLI < Thor
 
       licenses = licenses_by_similarity(matched_file)
       next if licenses.empty?
+
       say '  Closest non-matching licenses:'
       rows = licenses[0...3].map do |license, similarity|
         spdx_id = license.meta['spdx-id']

--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -26,6 +26,7 @@ module Licensee
     # Number of characteres in the normalized content
     def length
       return 0 unless content_normalized
+
       content_normalized.length
     end
 
@@ -74,6 +75,7 @@ module Licensee
     # Returns a string
     def content_normalized(wrap: nil)
       return unless content
+
       @content_normalized ||= begin
         string = content_without_title_and_version.downcase
         while string =~ Matchers::Copyright::REGEX
@@ -99,6 +101,7 @@ module Licensee
     # Wrap text to the given line length
     def self.wrap(text, line_width = 80)
       return if text.nil?
+
       text = text.clone
       text.gsub!(/([^\n])\n([^\n])/, '\1 \2')
 
@@ -125,6 +128,7 @@ module Licensee
       # families, but for sake of normalization, we can be less strict
       without_versions = licenses.map do |license|
         next if license.title == license.name_without_version
+
         Regexp.new Regexp.escape(license.name_without_version), 'i'
       end
       titles.concat(without_versions.compact)

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -17,7 +17,7 @@ module Licensee
       def all(options = {})
         @all[options] ||= begin
           # TODO: Remove in next major version to avoid breaking change
-          options[:pseudo] ||= options[:psuedo]
+          options[:pseudo] ||= options[:psuedo] unless options[:psuedo].nil?
 
           options = DEFAULT_OPTIONS.merge(options)
           output = licenses.dup
@@ -35,7 +35,7 @@ module Licensee
       end
 
       def find(key, options = {})
-        options = { hidden: true, pseudo: true }.merge(options)
+        options = { hidden: true }.merge(options)
         keys_licenses(options)[key.downcase]
       end
       alias [] find
@@ -128,8 +128,8 @@ module Licensee
 
     # Returns the human-readable license name
     def name
-      return title || spdx_id unless pseudo_license?
-      key.tr('-', ' ').capitalize
+      return key.tr('-', ' ').capitalize if pseudo_license?
+      title || spdx_id
     end
 
     def name_without_version

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -16,10 +16,13 @@ module Licensee
       # Returns an Array of License objects.
       def all(options = {})
         @all[options] ||= begin
+          # TODO: Remove in next major version to avoid breaking change
+          options[:pseudo] ||= options[:psuedo]
+
           options = DEFAULT_OPTIONS.merge(options)
           output = licenses.dup
           output.reject!(&:hidden?) unless options[:hidden]
-          output.reject!(&:pseudo_license?) unless options[:psuedo]
+          output.reject!(&:pseudo_license?) unless options[:pseudo]
           return output if options[:featured].nil?
           output.select { |l| l.featured? == options[:featured] }
         end
@@ -32,7 +35,7 @@ module Licensee
       end
 
       def find(key, options = {})
-        options = { hidden: true }.merge(options)
+        options = { hidden: true, pseudo: true }.merge(options)
         keys_licenses(options)[key.downcase]
       end
       alias [] find
@@ -40,7 +43,7 @@ module Licensee
 
       # Given a license title or nickname, fuzzy match the license
       def find_by_title(title)
-        License.all(hidden: true, psuedo: false).find do |license|
+        License.all(hidden: true, pseudo: false).find do |license|
           title =~ /\A(the )?#{license.title_regex}( license)?\z/i
         end
       end
@@ -82,7 +85,7 @@ module Licensee
     DEFAULT_OPTIONS = {
       hidden:   false,
       featured: nil,
-      psuedo:   true
+      pseudo:   true
     }.freeze
 
     ALT_TITLE_REGEX = {
@@ -125,7 +128,8 @@ module Licensee
 
     # Returns the human-readable license name
     def name
-      title || spdx_id
+      return title || spdx_id unless pseudo_license?
+      key.tr('-', ' ').capitalize
     end
 
     def name_without_version

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -24,6 +24,7 @@ module Licensee
           output.reject!(&:hidden?) unless options[:hidden]
           output.reject!(&:pseudo_license?) unless options[:pseudo]
           return output if options[:featured].nil?
+
           output.select { |l| l.featured? == options[:featured] }
         end
       end
@@ -129,6 +130,7 @@ module Licensee
     # Returns the human-readable license name
     def name
       return key.tr('-', ' ').capitalize if pseudo_license?
+
       title || spdx_id
     end
 
@@ -246,11 +248,13 @@ module Licensee
       unless File.exist?(path)
         raise Licensee::InvalidLicense, "'#{key}' is not a valid license key"
       end
+
       @raw_content ||= File.read(path, encoding: 'utf-8')
     end
 
     def parts
       return unless raw_content
+
       @parts ||= raw_content.match(/\A(---\n.*\n---\n+)?(.*)/m).to_a
     end
 

--- a/lib/licensee/license_field.rb
+++ b/lib/licensee/license_field.rb
@@ -39,6 +39,7 @@ module Licensee
       # Given a license body, returns an array of included LicneseFields
       def from_content(content)
         return [] unless content
+
         LicenseField.from_array content.scan(FIELD_REGEX).flatten
       end
     end

--- a/lib/licensee/license_meta.rb
+++ b/lib/licensee/license_meta.rb
@@ -23,6 +23,7 @@ module Licensee
       # returns a LicenseMeta with defaults set
       def from_yaml(yaml)
         return from_hash({}) if yaml.nil? || yaml.to_s.empty?
+
         from_hash YAML.safe_load(yaml)
       end
 

--- a/lib/licensee/matchers/cran.rb
+++ b/lib/licensee/matchers/cran.rb
@@ -15,6 +15,7 @@ module Licensee
       # or `nil` if no license field is found
       def license_field
         return @license_field if defined? @license_field
+
         match = @file.content.match LICENSE_FIELD_REGEX
         @license_field = match ? match[1].downcase : nil
       end
@@ -30,6 +31,7 @@ module Licensee
       # Rerurns `nil` if no license is found
       def license_property
         return unless license_field
+
         # Remove The common + file LICENSE text
         license_key = license_field.sub(PLUS_FILE_LICENSE_REGEX, '')
         gpl_version(license_key) || license_key

--- a/lib/licensee/matchers/exact.rb
+++ b/lib/licensee/matchers/exact.rb
@@ -3,6 +3,7 @@ module Licensee
     class Exact < Licensee::Matchers::Matcher
       def match
         return @match if defined? @match
+
         @match = potential_matches.find do |potential_match|
           potential_match.wordset == file.wordset
         end

--- a/lib/licensee/matchers/gemspec.rb
+++ b/lib/licensee/matchers/gemspec.rb
@@ -34,6 +34,7 @@ module Licensee
 
         # use 'other' if array contains multiple licenses
         return 'other' unless licenses.size == 1
+
         licenses[0]
       end
 

--- a/lib/licensee/matchers/package.rb
+++ b/lib/licensee/matchers/package.rb
@@ -4,6 +4,7 @@ module Licensee
       def match
         return @match if defined? @match
         return if license_property.nil? || license_property.to_s.empty?
+
         @match = Licensee.licenses(hidden: true).find do |license|
           license.key == license_property
         end

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -55,6 +55,7 @@ module Licensee
       def attribution
         @attribution ||= begin
           return unless copyright? || license.content =~ /\[fullname\]/
+
           matches = Matchers::Copyright::REGEX
                     .match(content_without_title_and_version)
           matches[0] if matches

--- a/lib/licensee/project_files/package_manager_file.rb
+++ b/lib/licensee/project_files/package_manager_file.rb
@@ -32,6 +32,7 @@ module Licensee
 
       def self.name_score(filename)
         return 1.0 if ['.gemspec', '.cabal'].include?(File.extname(filename))
+
         FILENAMES_SCORES[filename] || 0.0
       end
 

--- a/lib/licensee/project_files/project_file.rb
+++ b/lib/licensee/project_files/project_file.rb
@@ -88,6 +88,7 @@ module Licensee
       def copyright?
         return false unless is_a?(LicenseFile)
         return false unless matcher.is_a?(Matchers::Copyright)
+
         filename =~ /\Acopyright(?:#{LicenseFile::OTHER_EXT_REGEX})?\z/i
       end
 

--- a/lib/licensee/projects/fs_project.rb
+++ b/lib/licensee/projects/fs_project.rb
@@ -36,6 +36,7 @@ module Licensee
           relative_dir = Pathname.new(dir).relative_path_from(dir_path).to_s
           Dir.glob(::File.join(dir, @pattern).tr('\\', '/')).map do |file|
             next unless ::File.file?(file)
+
             { name: ::File.basename(file), dir: relative_dir }
           end.compact
         end

--- a/lib/licensee/projects/github_project.rb
+++ b/lib/licensee/projects/github_project.rb
@@ -20,6 +20,7 @@ module Licensee
       def initialize(github_url, **args)
         @repo = github_url[GITHUB_REPO_PATTERN, 1]
         raise ArgumentError, "Not a github URL: #{github_url}" unless @repo
+
         super(**args)
       end
 
@@ -29,8 +30,10 @@ module Licensee
 
       def files
         return @files if defined? @files_from_tree
+
         @files = dir_files
         return @files unless @files.empty?
+
         msg = "Could not load GitHub repo #{repo}, it may be private or deleted"
         raise RepoNotFound, msg
       end

--- a/lib/licensee/projects/project.rb
+++ b/lib/licensee/projects/project.rb
@@ -21,6 +21,7 @@ module Licensee
       # Returns the matching License instance if a license can be detected
       def license
         return @license if defined? @license
+
         @license = if licenses_without_copyright.count == 1 || lgpl?
           licenses_without_copyright.first
         elsif licenses_without_copyright.count > 1
@@ -53,6 +54,7 @@ module Licensee
       def license_files
         @license_files ||= begin
           return [] if files.empty? || files.nil?
+
           files = find_files do |n|
             Licensee::ProjectFiles::LicenseFile.name_score(n)
           end
@@ -67,6 +69,7 @@ module Licensee
       def readme_file
         return unless detect_readme?
         return @readme if defined? @readme
+
         @readme = begin
           content, file = find_file do |n|
             Licensee::ProjectFiles::ReadmeFile.name_score(n)
@@ -74,6 +77,7 @@ module Licensee
           content = Licensee::ProjectFiles::ReadmeFile.license_content(content)
 
           return unless content && file
+
           Licensee::ProjectFiles::ReadmeFile.new(content, file)
         end
       end
@@ -82,12 +86,14 @@ module Licensee
       def package_file
         return unless detect_packages?
         return @package_file if defined? @package_file
+
         @package_file = begin
           content, file = find_file do |n|
             Licensee::ProjectFiles::PackageManagerFile.name_score(n)
           end
 
           return unless content && file
+
           Licensee::ProjectFiles::PackageManagerFile.new(content, file)
         end
       end
@@ -96,6 +102,7 @@ module Licensee
 
       def lgpl?
         return false unless licenses.count == 2 && license_files.count == 2
+
         license_files[0].lgpl? && license_files[1].gpl?
       end
 
@@ -104,6 +111,7 @@ module Licensee
       # sorted by file score descending
       def find_files
         return [] if files.empty? || files.nil?
+
         found = files.map { |file| file.merge(score: yield(file[:name])) }
         found.select! { |file| file[:score] > 0 }
         found.sort { |a, b| b[:score] <=> a[:score] }
@@ -114,6 +122,7 @@ module Licensee
       # or nil, if no file scored > 0
       def find_file(&block)
         return if files.empty? || files.nil?
+
         file = find_files(&block).first
         [load_file(file), file] if file
       end

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -491,6 +491,7 @@ RSpec.describe Licensee::License do
                   context "with '#{suffix}' after the path" do
                     before do
                       next if license.key == 'wtfpl'
+
                       regex = /#{Licensee::License::SOURCE_SUFFIX}\z/
                       source.path = source.path.sub(regex, '')
                       source.path = "#{source.path}#{suffix}"

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -54,8 +54,7 @@ RSpec.describe Licensee::License do
       it 'includes hidden licenses' do
         expect(licenses).to include(cc_by)
         expect(licenses).to include(mit)
-        expect(licenses).to_not include(other)
-        expect(licenses.count).to eql(license_count - pseudo_license_count)
+        expect(licenses.count).to eql(license_count)
       end
     end
 
@@ -87,10 +86,7 @@ RSpec.describe Licensee::License do
           expect(licenses).to include(unlicense)
           expect(licenses).to include(cc_by)
           expect(licenses).to_not include(mit)
-          expect(licenses).to_not include(other)
-          expected = license_count - featured_license_count
-          expected -= pseudo_license_count
-          expect(licenses.count).to eql(expected)
+          expect(licenses.count).to eql(license_count - featured_license_count)
         end
       end
     end
@@ -109,8 +105,8 @@ RSpec.describe Licensee::License do
       context 'with hidden licenses' do
         let(:arguments) { { hidden: true } }
 
-        it "doesn't include pseudo licenses" do
-          expect(licenses).to_not include(other)
+        it 'includes pseudo licenses' do
+          expect(licenses).to include(other)
         end
       end
 

--- a/spec/licensee_spec.rb
+++ b/spec/licensee_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Licensee do
   let(:project_path) { fixture_path('mit') }
   let(:license_path) { fixture_path('mit/LICENSE.txt') }
   let(:mit_license) { Licensee::License.find('mit') }
-  let(:hidden_license_count) { 36 }
+  let(:hidden_license_count) { 34 }
 
   it 'exposes licenses' do
     expect(described_class.licenses).to be_an(Array)

--- a/spec/licensee_spec.rb
+++ b/spec/licensee_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Licensee do
   let(:project_path) { fixture_path('mit') }
   let(:license_path) { fixture_path('mit/LICENSE.txt') }
   let(:mit_license) { Licensee::License.find('mit') }
-  let(:hidden_license_count) { 34 }
+  let(:hidden_license_count) { 36 }
 
   it 'exposes licenses' do
     expect(described_class.licenses).to be_an(Array)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -109,6 +109,7 @@ RSpec::Matchers.define :be_detected_as do |expected|
     license_file = Licensee::ProjectFiles::LicenseFile.new(actual, 'LICENSE')
     @actual = license_file.content_normalized(wrap: 80)
     return false unless license_file.license
+
     values_match? expected, license_file.license
   end
 


### PR DESCRIPTION
In https://github.com/benbalter/licensee/pull/297 we set the proper `spdx_id` for the `other` and `no-license` pseudo licenses. In https://github.com/benbalter/licensee/commit/7166a9cf3bf424e19f2998e1ba947c18cb9926a6, the `License#name` logic changed slightly to look to the SPDX ID, instead of the key, when no title was present in the metadata.

Both changes were valid changes, and in the case of most licenses, would result in a better non-title fallback, but combined, changed the intended-to-be-human-readable`License#name` for pseudo licenses from the capitalized key to the raw SPDX ID (e.g., `NOASSERTION` instead of `No license`).

This PR updates the logic for pseudo licenses to return the humanized key, rather than the raw SPDX ID ensuring `Licensee::License.find('other').name` returns `Other` rather than `NOASSERTION`, which is more human readable (and the old behavior).

Additionally in tracking this bug down, I noticed we (I) switched between `pseudo` and `psuedo` (and in some cases `psudo`), meaning arguments weren't always properly passed around. This PR also correct the spelling of the argument in a backwards compatible way such that `psuedo` will be transformed to `pseudo` if `psuedo` is not otherwise passed.
