### PR TITLE
Fixing cabal licenses handling

### DIFF
--- a/lib/licensee/matchers/cabal.rb
+++ b/lib/licensee/matchers/cabal.rb
@@ -4,12 +4,29 @@ module Licensee
       # While we could parse the cabal file, prefer
       # a lenient regex for speed and security. Moar parsing moar problems.
       LICENSE_REGEX = /^\s*license\s*\:\s*([a-z\-0-9\.]+)\s*$/ix.freeze
+      LICENSE_CONVERSIONS = {
+        'GPL-2'      => 'GPL-2.0',
+        'GPL-3'      => 'GPL-3.0',
+        'LGPL-2.1'   => 'LGPL-2.1',
+        'LGPL-3'     => 'LGPL-3.0',
+        'AGPL-3'     => 'AGPL-3.0',
+        'BSD2'       => 'BSD-2-Clause',
+        'BSD3'       => 'BSD-3-Clause',
+        'MIT'        => 'MIT',
+        'ISC'        => 'ISC',
+        'MPL-2.0'    => 'MPL-2.0',
+        'Apache-2.0' => 'Apache-2.0'
+      }.freeze
 
       private
 
       def license_property
         match = @file.content.match LICENSE_REGEX
-        match[1].downcase if match && match[1]
+        spdx_name(match[1]).downcase if match && match[1]
+      end
+
+      def spdx_name(cabal_name)
+        LICENSE_CONVERSIONS[cabal_name] || cabal_name
       end
     end
   end

--- a/lib/licensee/matchers/cabal.rb
+++ b/lib/licensee/matchers/cabal.rb
@@ -5,17 +5,12 @@ module Licensee
       # a lenient regex for speed and security. Moar parsing moar problems.
       LICENSE_REGEX = /^\s*license\s*\:\s*([a-z\-0-9\.]+)\s*$/ix.freeze
       LICENSE_CONVERSIONS = {
-        'GPL-2'      => 'GPL-2.0',
-        'GPL-3'      => 'GPL-3.0',
-        'LGPL-2.1'   => 'LGPL-2.1',
-        'LGPL-3'     => 'LGPL-3.0',
-        'AGPL-3'     => 'AGPL-3.0',
-        'BSD2'       => 'BSD-2-Clause',
-        'BSD3'       => 'BSD-3-Clause',
-        'MIT'        => 'MIT',
-        'ISC'        => 'ISC',
-        'MPL-2.0'    => 'MPL-2.0',
-        'Apache-2.0' => 'Apache-2.0'
+        'GPL-2'  => 'GPL-2.0',
+        'GPL-3'  => 'GPL-3.0',
+        'LGPL-3' => 'LGPL-3.0',
+        'AGPL-3' => 'AGPL-3.0',
+        'BSD2'   => 'BSD-2-Clause',
+        'BSD3'   => 'BSD-3-Clause'
       }.freeze
 
       private

--- a/spec/licensee/matchers/cabal_matcher_spec.rb
+++ b/spec/licensee/matchers/cabal_matcher_spec.rb
@@ -77,7 +77,6 @@ RSpec.describe Licensee::Matchers::Cabal do
       end
     end
 
-
     context 'BSD3' do
       let(:cabal_license) { 'BSD3' }
 

--- a/spec/licensee/matchers/cabal_matcher_spec.rb
+++ b/spec/licensee/matchers/cabal_matcher_spec.rb
@@ -27,6 +27,98 @@ RSpec.describe Licensee::Matchers::Cabal do
     end
   end
 
+  context 'non-standard license format' do
+    let(:content) { "license: #{cabal_license}" }
+    context 'GPL-3' do
+      let(:cabal_license) { 'GPL-3' }
+
+      it 'returns GPL-3.0' do
+        expect(subject.match).to eql(Licensee::License.find('GPL-3.0'))
+      end
+    end
+
+    context 'GPL-2' do
+      let(:cabal_license) { 'GPL-2' }
+
+      it 'returns GPL-2.0' do
+        expect(subject.match).to eql(Licensee::License.find('GPL-2.0'))
+      end
+    end
+
+    context 'LGPL-2.1' do
+      let(:cabal_license) { 'LGPL-2.1' }
+
+      it 'returns LGPL-2.1' do
+        expect(subject.match).to eql(Licensee::License.find('LGPL-2.1'))
+      end
+    end
+
+    context 'LGPL-3' do
+      let(:cabal_license) { 'LGPL-3' }
+
+      it 'returns LGPL-3.0' do
+        expect(subject.match).to eql(Licensee::License.find('LGPL-3.0'))
+      end
+    end
+
+    context 'AGPL-3' do
+      let(:cabal_license) { 'AGPL-3' }
+
+      it 'returns AGPL-3.0' do
+        expect(subject.match).to eql(Licensee::License.find('AGPL-3.0'))
+      end
+    end
+
+    context 'BSD2' do
+      let(:cabal_license) { 'BSD2' }
+
+      it 'returns BSD-2-Clause' do
+        expect(subject.match).to eql(Licensee::License.find('BSD-2-Clause'))
+      end
+    end
+
+
+    context 'BSD3' do
+      let(:cabal_license) { 'BSD3' }
+
+      it 'returns BSD-3-Clause' do
+        expect(subject.match).to eql(Licensee::License.find('BSD-3-Clause'))
+      end
+    end
+
+    context 'MIT' do
+      let(:cabal_license) { 'MIT' }
+
+      it 'returns MIT' do
+        expect(subject.match).to eql(Licensee::License.find('MIT'))
+      end
+    end
+
+    context 'ISC' do
+      let(:cabal_license) { 'ISC' }
+
+      it 'returns ISC' do
+        expect(subject.match).to eql(Licensee::License.find('ISC'))
+      end
+    end
+
+    context 'MPL-2.0' do
+      let(:cabal_license) { 'MPL-2.0' }
+
+      it 'returns MPL-2.0' do
+        expect(subject.match).to eql(Licensee::License.find('MPL-2.0'))
+      end
+    end
+
+    context 'Apache-2.0' do
+      let(:cabal_license) { 'Apache-2.0' }
+
+      it 'returns Apache-2.0' do
+        expect(subject.match).to eql(Licensee::License.find('Apache-2.0'))
+      end
+    end
+  end
+
   context 'no license field' do
     let(:content) { 'foo: bar' }
 


### PR DESCRIPTION
Fixes #356

This PR only affects some licenses: 

* most GPL and GPL-derivative license
* BSD licenses

The other already supported licenses where already working. Also, unrecognized cabal licenses are preserved without changes. 

Finally, there are some other cabal licenses that are not explicitly handled, as you can check with an invalid cabal file: 

``
$ cabal check
Warning: The following warnings are likely to affect your build negatively:
Warning: 'license: VGPL-4.0' is not a recognised license. The known licenses
are: GPL, GPL-2, GPL-3, LGPL, LGPL-2.1, LGPL-3, AGPL, AGPL-3, BSD2, BSD3, MIT,
ISC, MPL-2.0, Apache, Apache-2.0, PublicDomain, AllRightsReserved,
OtherLicense
```

I did not add explicit support for them just because different reasons: 

* `GPL`, `APL`, `LGPL` without version numbers are ambiguous 
* `PublicDomain`, `OtherLicense`, `AllRightsReserved` are not actually licenses, as far as I understand. 
