### PR TITLE
fix error on new git init

### DIFF
--- a/lib/licensee/projects/git_project.rb
+++ b/lib/licensee/projects/git_project.rb
@@ -22,6 +22,8 @@ module Licensee
           Rugged::Repository.new(repo)
         end
 
+        raise InvalidRepository if repository.head_unborn?
+
         @revision = revision
         super(**args)
       rescue Rugged::OSError, Rugged::RepositoryError

--- a/lib/licensee/projects/git_project.rb
+++ b/lib/licensee/projects/git_project.rb
@@ -11,27 +11,31 @@ autoload :Rugged, 'rugged'
 module Licensee
   module Projects
     class GitProject < Licensee::Projects::Project
-      attr_reader :repository, :revision
+      attr_reader :revision
 
       class InvalidRepository < ArgumentError; end
 
       def initialize(repo, revision: nil, **args)
-        @repository = if repo.is_a? Rugged::Repository
-          repo
-        else
-          Rugged::Repository.new(repo)
-        end
+        @raw_repo = repo
+        @revision = revision
 
         raise InvalidRepository if repository.head_unborn?
 
-        @revision = revision
         super(**args)
+      end
+
+      def repository
+        @repository ||= begin
+          return @raw_repo if @raw_repo.is_a? Rugged::Repository
+
+          Rugged::Repository.new(@raw_repo)
+        end
       rescue Rugged::OSError, Rugged::RepositoryError
         raise InvalidRepository
       end
 
       def close
-        @repository.close
+        repository.close
       end
 
       private

--- a/spec/licensee/projects/git_project_spec.rb
+++ b/spec/licensee/projects/git_project_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Licensee::Projects::GitProject do
+  let(:fixture) { 'mit' }
+
+  context 'new git repo handled as file system project' do
+    let(:path) { fixture_path(fixture) }
+
+    before do
+      Dir.chdir path do
+        `git init`
+      end
+    end
+
+    after do
+      FileUtils.rm_rf File.expand_path '.git', path
+    end
+
+    it 'raises InvalidRepository error' do
+      expect { described_class.new(path) }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the issue #312  . If the repo is fresh initialized, the commit function in GitProject fails as there is no commit , to prevent this , thit PR checks for a head_unborn? in the initialize and raises InvalidRepository error, so that the project can be treated as File System project.

I wasn't sure how to write tests for this. I couldn't find any similar example of it in the specs.

EDIT: There seems to be 2 ways to decrease cognitive complexity. Either I can call commit function directly, raise `rugged::ReferenceError` and then catch it in rescue or we can move `if repo.is_a? Rug..` block to a private method.